### PR TITLE
runtime: add kernel features auto-detection

### DIFF
--- a/examples/legacy.rs
+++ b/examples/legacy.rs
@@ -1,0 +1,13 @@
+extern crate caps;
+
+use caps::runtime;
+
+fn main() {
+    let amb_set = runtime::ambient_set_supported().is_ok();
+    println!("Ambient set supported: {}", amb_set);
+
+    let all = caps::all();
+    let supported = runtime::all_supported();
+    let missing = all.difference(&supported);
+    println!("Unsupported new capabilities: {:?}", missing);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,23 +22,15 @@
 extern crate error_chain;
 extern crate libc;
 
+mod ambient;     // Implementation of Ambient set
+mod base;        // Implementation of POSIX sets
+mod bounding;    // Implementation of Bounding set
+mod nr;          // All kernel-related constants
+pub mod errors;  // Error wrapping
+pub mod runtime; // Features/legacy detection at runtime
+
 use std::iter::FromIterator;
-
-// Error wrapping
-pub mod errors;
 use errors::*;
-
-// All kernel-related constants
-mod nr;
-
-// Implementation of POSIX sets
-mod base;
-
-// Implementation of Ambient set
-mod ambient;
-
-// Implementation of Bounding set
-mod bounding;
 
 /// Linux capabilities sets.
 ///

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,30 @@
+//! Detect kernel features at runtime.
+//!
+//! This module exposes methods to perform detection of kernel
+//! features at runtime. This allows applications to auto-detect
+//! whether recent options are implemented by the currently
+//! running kernel.
+
+use errors::*;
+use super::{ambient, Capability, CapsHashSet, CapSet};
+
+/// Check whether the running kernel supports the ambient set.
+///
+/// Ambient set was introduced in Linux kernel 4.3. On recent kernels
+/// where the ambient set is supported, this will return `Ok`.
+/// On a legacy kernel, an `Err` is returned instead.
+pub fn ambient_set_supported() -> Result<()> {
+    ambient::has_cap(Capability::CAP_CHOWN)?;
+    Ok(())
+}
+
+/// Return an `HashSet` with all capabilities supported by the running kernel.
+pub fn all_supported() -> CapsHashSet {
+    let mut supported = super::all();
+    for c in super::all() {
+        if super::has_cap(None, CapSet::Bounding, c).is_err() {
+            supported.remove(&c);
+        }
+    }
+    supported
+}

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1,0 +1,12 @@
+extern crate caps;
+use caps::runtime;
+
+#[test]
+fn test_ambient_supported() {
+    runtime::ambient_set_supported().unwrap();
+}
+
+#[test]
+fn test_all_supported() {
+    assert_eq!(runtime::all_supported(), caps::all());
+}


### PR DESCRIPTION
This introduces a module with some methods to detect kernel features
at runtime.

Fixes https://github.com/lucab/caps-rs/issues/7