### PR TITLE
Change type for x86 constants in nr

### DIFF
--- a/src/nr.rs
+++ b/src/nr.rs
@@ -52,9 +52,9 @@ pub const PR_CAP_AMBIENT_CLEAR_ALL: i32 = 4;
 /* from <unistd.h> */
 
 #[cfg(target_arch = "x86")]
-pub const CAPGET: i64 = 184;
+pub const CAPGET: i32 = 184;
 #[cfg(target_arch = "x86")]
-pub const CAPSET: i64 = 185;
+pub const CAPSET: i32 = 185;
 
 #[cfg(target_arch = "x86_64")]
 pub const CAPGET: i64 = 125;


### PR DESCRIPTION
For x86 (32bit) the required type for the libc::syscall is i32 over i64.
This changes the type of the constants in nr.rs so the crate compiles on
that architecture.

Fixes #17 