### PR TITLE
securebits: add support for keepcaps flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,12 +23,13 @@ extern crate error_chain;
 extern crate errno;
 extern crate libc;
 
-mod ambient;     // Implementation of Ambient set
-mod base;        // Implementation of POSIX sets
-mod bounding;    // Implementation of Bounding set
-mod nr;          // All kernel-related constants
-pub mod errors;  // Error wrapping
-pub mod runtime; // Features/legacy detection at runtime
+mod ambient;        // Implementation of Ambient set
+mod base;           // Implementation of POSIX sets
+mod bounding;       // Implementation of Bounding set
+mod nr;             // All kernel-related constants
+pub mod errors;     // Error wrapping
+pub mod runtime;    // Features/legacy detection at runtime
+pub mod securebits; // Thread security bits
 
 use std::iter::FromIterator;
 use errors::*;

--- a/src/nr.rs
+++ b/src/nr.rs
@@ -41,6 +41,8 @@ pub const CAP_AUDIT_READ: u8 = 37;
 
 /* from <sys/prctl.h> */
 
+pub const PR_GET_KEEPCAPS: i32 = 7;
+pub const PR_SET_KEEPCAPS: i32 = 8;
 pub const PR_CAPBSET_READ: i32 = 23;
 pub const PR_CAPBSET_DROP: i32 = 24;
 pub const PR_CAP_AMBIENT: i32 = 47;

--- a/src/securebits.rs
+++ b/src/securebits.rs
@@ -1,0 +1,35 @@
+//! Manipulate securebits flags
+//!
+//! This module exposes methods to get and set per-thread securebits
+//! flags, which can be used to disable special handling of capabilities
+//! for UID 0 (root).
+
+use errno;
+use libc;
+
+use errors::*;
+use nr;
+
+/// Return whether the current thread's "keep capabilities" flag is set.
+pub fn has_keepcaps() -> Result<bool> {
+    let ret = unsafe { libc::prctl(nr::PR_GET_KEEPCAPS, 0, 0, 0) };
+    match ret {
+        0 => Ok(false),
+        1 => Ok(true),
+        _ => Err(
+            Error::from_kind(ErrorKind::Sys(errno::errno())).chain_err(|| "PR_GET_KEEPCAPS error")
+        ),
+    }
+}
+
+/// Set the value of the current thread's "keep capabilities" flag.
+pub fn set_keepcaps(keep_caps: bool) -> Result<()> {
+    let flag = if keep_caps { 1 } else { 0 };
+    let ret = unsafe { libc::prctl(nr::PR_SET_KEEPCAPS, flag, 0, 0) };
+    match ret {
+        0 => Ok(()),
+        _ => Err(
+            Error::from_kind(ErrorKind::Sys(errno::errno())).chain_err(|| "PR_SET_KEEPCAPS error")
+        ),
+    }
+}

--- a/tests/securebits.rs
+++ b/tests/securebits.rs
@@ -1,0 +1,14 @@
+extern crate caps;
+use caps::securebits;
+
+#[test]
+fn test_keepcaps() {
+    // Test a roundtrip on SET_KEEPCAPS.
+    let f0 = securebits::has_keepcaps().unwrap();
+    securebits::set_keepcaps(!f0).unwrap();
+    let f1 = securebits::has_keepcaps().unwrap();
+    assert_eq!(f0, !f1);
+    securebits::set_keepcaps(!f1).unwrap();
+    let f2 = securebits::has_keepcaps().unwrap();
+    assert_eq!(f0, f2);
+}


### PR DESCRIPTION
This adds initial support for securebits, starting from
`GET_KEEPCAPS` and `SET_KEEPCAPS`.

Closes: https://github.com/lucab/caps-rs/issues/26