### PR TITLE
nr: fix build on sparc and sparc64

### DIFF
--- a/src/nr.rs
+++ b/src/nr.rs
@@ -97,3 +97,8 @@ pub const CAPSET: i32 = 185;
 pub const CAPGET: i64 = 184;
 #[cfg(target_arch = "s390x")]
 pub const CAPSET: i64 = 185;
+
+#[cfg(target_arch = "sparc")]
+pub const CAPGET: i64 = 21;
+#[cfg(target_arch = "sparc")]
+pub const CAPSET: i64 = 22;

--- a/src/nr.rs
+++ b/src/nr.rs
@@ -102,3 +102,8 @@ pub const CAPSET: i64 = 185;
 pub const CAPGET: i64 = 21;
 #[cfg(target_arch = "sparc")]
 pub const CAPSET: i64 = 22;
+
+#[cfg(target_arch = "sparc64")]
+pub const CAPGET: i64 = 21;
+#[cfg(target_arch = "sparc64")]
+pub const CAPSET: i64 = 22;


### PR DESCRIPTION
caps-rs currently fails to build on Debian sparc64 with:

```
error[E0425]: cannot find value `CAPGET` in module `nr`
  --> src/base.rs:12:40
   |
12 |     let r = unsafe { libc::syscall(nr::CAPGET, hdr, data) };
   |                                        ^^^^^^ not found in `nr`

error[E0425]: cannot find value `CAPSET` in module `nr`
  --> src/base.rs:20:40
   |
20 |     let r = unsafe { libc::syscall(nr::CAPSET, hdr, data) };
   |                                        ^^^^^^ not found in `nr`

error: aborting due to 2 previous errors
```

With this PR, caps-rs builds fine on Debian sparc64.