### PR TITLE
caps: change API to borrow, update to 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: rust
 
 rust:
-  - nightly-2018-07-24  # pinned toolchain for clippy
-  - 1.26.0              # minimum supported toolchain
+  - nightly-2019-09-13  # pinned toolchain for clippy
   - stable
   - beta
   - nightly
@@ -13,7 +12,7 @@ matrix:
 
 env:
   global:
-    - CLIPPY_RUST_VERSION=nightly-2018-07-24
+    - CLIPPY_RUST_VERSION=nightly-2019-09-13
 
 before_script:
   - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 
 [dependencies]
 errno = "0.2"
-error-chain = {version = "0.12", default-features = false}
+failure = "0.1"
 libc = "0.2"
 
 [package.metadata.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "caps"
 version = "0.3.4-alpha.0"
 authors = ["Luca Bruno <lucab@debian.org>"]
 license = "MIT/Apache-2.0"
+edition = "2018"
 repository = "https://github.com/lucab/caps-rs"
 documentation = "https://docs.rs/caps"
 description = "A pure-Rust library to work with Linux capabilities"

--- a/examples/clear_except_chown.rs
+++ b/examples/clear_except_chown.rs
@@ -1,5 +1,3 @@
-extern crate caps;
-
 use caps::{CapSet, Capability, CapsHashSet};
 
 fn main() {

--- a/examples/clear_except_chown.rs
+++ b/examples/clear_except_chown.rs
@@ -1,0 +1,14 @@
+extern crate caps;
+
+use caps::{CapSet, Capability, CapsHashSet};
+
+fn main() {
+    let mut set = CapsHashSet::new();
+    set.insert(Capability::CAP_CHOWN);
+    caps::set(None, CapSet::Effective, &set).unwrap();
+    caps::set(None, CapSet::Permitted, &set).unwrap();
+    let perm = caps::read(None, CapSet::Permitted).unwrap();
+    println!("Permitted {:?}", perm);
+    let eff = caps::read(None, CapSet::Effective).unwrap();
+    println!("Effective {:?}", eff);
+}

--- a/examples/clear_permitted.rs
+++ b/examples/clear_permitted.rs
@@ -6,8 +6,6 @@
 //! This is a caps example ONLY: do NOT panic/unwrap/assert
 //! in production code!
 
-extern crate caps;
-
 use caps::{CapSet, Capability};
 
 fn main() {

--- a/examples/legacy.rs
+++ b/examples/legacy.rs
@@ -1,5 +1,3 @@
-extern crate caps;
-
 use caps::runtime;
 
 fn main() {

--- a/examples/manipulate_sys_nice.rs
+++ b/examples/manipulate_sys_nice.rs
@@ -6,9 +6,6 @@
 //! This is a caps example ONLY: do NOT panic/unwrap/assert
 //! in production code!
 
-extern crate caps;
-extern crate libc;
-
 use caps::{CapSet, Capability};
 
 fn main() {

--- a/examples/parse.rs
+++ b/examples/parse.rs
@@ -1,5 +1,3 @@
-extern crate caps;
-
 use caps::Capability;
 use std::str::FromStr;
 

--- a/src/ambient.rs
+++ b/src/ambient.rs
@@ -1,13 +1,14 @@
-use super::Capability;
+use failure::ResultExt;
+
 use crate::errors::*;
 use crate::nr;
+use crate::Capability;
 
 pub fn clear() -> Result<()> {
     let ret = unsafe { libc::prctl(nr::PR_CAP_AMBIENT, nr::PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0) };
     match ret {
         0 => Ok(()),
-        _ => Err(Error::from_kind(ErrorKind::Sys(errno::errno()))
-            .chain_err(|| "PR_CAP_AMBIENT_CLEAR_ALL error")),
+        _ => Err(Error::Sys(errno::errno())).context("PR_CAP_AMBIENT_CLEAR_ALL error")?,
     }
 }
 
@@ -23,8 +24,7 @@ pub fn drop(cap: Capability) -> Result<()> {
     };
     match ret {
         0 => Ok(()),
-        _ => Err(Error::from_kind(ErrorKind::Sys(errno::errno()))
-            .chain_err(|| "PR_CAP_AMBIENT_LOWER error")),
+        _ => Err(Error::Sys(errno::errno())).context("PR_CAP_AMBIENT_LOWER error")?,
     }
 }
 
@@ -41,8 +41,7 @@ pub fn has_cap(cap: Capability) -> Result<bool> {
     match ret {
         0 => Ok(false),
         1 => Ok(true),
-        _ => Err(Error::from_kind(ErrorKind::Sys(errno::errno()))
-            .chain_err(|| "PR_CAP_AMBIENT_IS_SET error")),
+        _ => Err(Error::Sys(errno::errno())).context("PR_CAP_AMBIENT_IS_SET error")?,
     }
 }
 
@@ -58,8 +57,7 @@ pub fn raise(cap: Capability) -> Result<()> {
     };
     match ret {
         0 => Ok(()),
-        _ => Err(Error::from_kind(ErrorKind::Sys(errno::errno()))
-            .chain_err(|| "PR_CAP_AMBIENT_RAISE error")),
+        _ => Err(Error::Sys(errno::errno())).context("PR_CAP_AMBIENT_RAISE error")?,
     }
 }
 

--- a/src/ambient.rs
+++ b/src/ambient.rs
@@ -1,9 +1,6 @@
-use errno;
-use libc;
-
 use super::Capability;
-use errors::*;
-use nr;
+use crate::errors::*;
+use crate::nr;
 
 pub fn clear() -> Result<()> {
     let ret = unsafe { libc::prctl(nr::PR_CAP_AMBIENT, nr::PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0) };

--- a/src/ambient.rs
+++ b/src/ambient.rs
@@ -69,7 +69,7 @@ pub fn raise(cap: Capability) -> Result<()> {
 pub fn read() -> Result<super::CapsHashSet> {
     let mut res = super::CapsHashSet::new();
     for c in super::all() {
-        if try!(has_cap(c)) {
+        if has_cap(c)? {
             res.insert(c);
         }
     }
@@ -79,9 +79,9 @@ pub fn read() -> Result<super::CapsHashSet> {
 pub fn set(value: &super::CapsHashSet) -> Result<()> {
     for c in super::all() {
         if value.contains(&c) {
-            try!(raise(c));
+            raise(c)?;
         } else {
-            try!(drop(c));
+            drop(c)?;
         };
     }
     Ok(())

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,9 +1,8 @@
-use errno;
-use libc;
+use error_chain::bail;
 
 use super::{CapSet, Capability};
-use errors::*;
-use nr;
+use crate::errors::*;
+use crate::nr;
 
 #[allow(unknown_lints, unreadable_literal)]
 const CAPS_V3: u32 = 0x20080522;

--- a/src/base.rs
+++ b/src/base.rs
@@ -4,7 +4,7 @@ use super::{CapSet, Capability};
 use crate::errors::*;
 use crate::nr;
 
-#[allow(unknown_lints, unreadable_literal)]
+#[allow(unknown_lints, clippy::unreadable_literal)]
 const CAPS_V3: u32 = 0x20080522;
 
 fn capget(hdr: &mut CapUserHeader, data: &mut CapUserData) -> Result<()> {

--- a/src/base.rs
+++ b/src/base.rs
@@ -94,7 +94,7 @@ pub fn read(tid: i32, cset: CapSet) -> Result<super::CapsHashSet> {
     Ok(res)
 }
 
-pub fn set(tid: i32, cset: CapSet, value: super::CapsHashSet) -> Result<()> {
+pub fn set(tid: i32, cset: CapSet, value: &super::CapsHashSet) -> Result<()> {
     let mut hdr = CapUserHeader {
         version: CAPS_V3,
         pid: tid,
@@ -129,7 +129,7 @@ pub fn set(tid: i32, cset: CapSet, value: super::CapsHashSet) -> Result<()> {
 pub fn drop(tid: i32, cset: CapSet, cap: Capability) -> Result<()> {
     let mut caps = try!(read(tid, cset));
     if caps.remove(&cap) {
-        try!(set(tid, cset, caps));
+        try!(set(tid, cset, &caps));
     };
     Ok(())
 }
@@ -137,7 +137,7 @@ pub fn drop(tid: i32, cset: CapSet, cap: Capability) -> Result<()> {
 pub fn raise(tid: i32, cset: CapSet, cap: Capability) -> Result<()> {
     let mut caps = try!(read(tid, cset));
     if caps.insert(cap) {
-        try!(set(tid, cset, caps));
+        try!(set(tid, cset, &caps));
     };
     Ok(())
 }

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,4 +1,4 @@
-use error_chain::bail;
+use failure::{bail, ResultExt};
 
 use super::{CapSet, Capability};
 use crate::errors::*;
@@ -11,7 +11,7 @@ fn capget(hdr: &mut CapUserHeader, data: &mut CapUserData) -> Result<()> {
     let r = unsafe { libc::syscall(nr::CAPGET, hdr, data) };
     match r {
         0 => Ok(()),
-        _ => Err(Error::from_kind(ErrorKind::Sys(errno::errno())).chain_err(|| "capget error")),
+        _ => Err(Error::Sys(errno::errno())).context("capget error")?,
     }
 }
 
@@ -19,7 +19,7 @@ fn capset(hdr: &mut CapUserHeader, data: &CapUserData) -> Result<()> {
     let r = unsafe { libc::syscall(nr::CAPSET, hdr, data) };
     match r {
         0 => Ok(()),
-        _ => Err(Error::from_kind(ErrorKind::Sys(errno::errno())).chain_err(|| "capset error")),
+        _ => Err(Error::Sys(errno::errno())).context("capset error")?,
     }
 }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -30,7 +30,7 @@ pub fn has_cap(tid: i32, cset: CapSet, cap: Capability) -> Result<bool> {
         pid: tid,
     };
     let mut data: CapUserData = Default::default();
-    try!(capget(&mut hdr, &mut data));
+    capget(&mut hdr, &mut data)?;
     let caps: u64 = match cset {
         CapSet::Effective => (u64::from(data.effective_s1) << 32) + u64::from(data.effective_s0),
         CapSet::Inheritable => {
@@ -49,7 +49,7 @@ pub fn clear(tid: i32, cset: CapSet) -> Result<()> {
         pid: tid,
     };
     let mut data: CapUserData = Default::default();
-    try!(capget(&mut hdr, &mut data));
+    capget(&mut hdr, &mut data)?;
     match cset {
         CapSet::Effective => {
             data.effective_s0 = 0;
@@ -76,7 +76,7 @@ pub fn read(tid: i32, cset: CapSet) -> Result<super::CapsHashSet> {
         pid: tid,
     };
     let mut data: CapUserData = Default::default();
-    try!(capget(&mut hdr, &mut data));
+    capget(&mut hdr, &mut data)?;
     let caps: u64 = match cset {
         CapSet::Effective => (u64::from(data.effective_s1) << 32) + u64::from(data.effective_s0),
         CapSet::Inheritable => {
@@ -100,7 +100,7 @@ pub fn set(tid: i32, cset: CapSet, value: &super::CapsHashSet) -> Result<()> {
         pid: tid,
     };
     let mut data: CapUserData = Default::default();
-    try!(capget(&mut hdr, &mut data));
+    capget(&mut hdr, &mut data)?;
     {
         let (s1, s0) = match cset {
             CapSet::Effective => (&mut data.effective_s1, &mut data.effective_s0),
@@ -112,32 +112,32 @@ pub fn set(tid: i32, cset: CapSet, value: &super::CapsHashSet) -> Result<()> {
         *s0 = 0;
         for c in value {
             match c.index() {
-                0...31 => {
+                0..=31 => {
                     *s0 |= c.bitmask() as u32;
                 }
-                32...63 => {
+                32..=63 => {
                     *s1 |= (c.bitmask() >> 32) as u32;
                 }
                 _ => bail!("overlarge cap index {}", c.index()),
             }
         }
     }
-    try!(capset(&mut hdr, &data));
+    capset(&mut hdr, &data)?;
     Ok(())
 }
 
 pub fn drop(tid: i32, cset: CapSet, cap: Capability) -> Result<()> {
-    let mut caps = try!(read(tid, cset));
+    let mut caps = read(tid, cset)?;
     if caps.remove(&cap) {
-        try!(set(tid, cset, &caps));
+        set(tid, cset, &caps)?;
     };
     Ok(())
 }
 
 pub fn raise(tid: i32, cset: CapSet, cap: Capability) -> Result<()> {
-    let mut caps = try!(read(tid, cset));
+    let mut caps = read(tid, cset)?;
     if caps.insert(cap) {
-        try!(set(tid, cset, &caps));
+        set(tid, cset, &caps)?;
     };
     Ok(())
 }

--- a/src/bounding.rs
+++ b/src/bounding.rs
@@ -1,9 +1,6 @@
-use errno;
-use libc;
-
 use super::Capability;
-use errors::*;
-use nr;
+use crate::errors::*;
+use crate::nr;
 
 pub fn clear() -> Result<()> {
     for c in super::all() {

--- a/src/bounding.rs
+++ b/src/bounding.rs
@@ -7,8 +7,8 @@ use nr;
 
 pub fn clear() -> Result<()> {
     for c in super::all() {
-        if try!(has_cap(c)) {
-            try!(drop(c));
+        if has_cap(c)? {
+            drop(c)?;
         }
     }
     Ok(())
@@ -40,7 +40,7 @@ pub fn has_cap(cap: Capability) -> Result<bool> {
 pub fn read() -> Result<super::CapsHashSet> {
     let mut res = super::CapsHashSet::new();
     for c in super::all() {
-        if try!(has_cap(c)) {
+        if has_cap(c)? {
             res.insert(c);
         }
     }

--- a/src/bounding.rs
+++ b/src/bounding.rs
@@ -1,6 +1,8 @@
-use super::Capability;
+use failure::ResultExt;
+
 use crate::errors::*;
 use crate::nr;
+use crate::{all, Capability, CapsHashSet};
 
 pub fn clear() -> Result<()> {
     for c in super::all() {
@@ -15,10 +17,7 @@ pub fn drop(cap: Capability) -> Result<()> {
     let ret = unsafe { libc::prctl(nr::PR_CAPBSET_DROP, libc::c_uint::from(cap.index()), 0, 0) };
     match ret {
         0 => Ok(()),
-        _ => {
-            Err(Error::from_kind(ErrorKind::Sys(errno::errno()))
-                .chain_err(|| "PR_CAPBSET_DROP error"))
-        }
+        _ => Err(Error::Sys(errno::errno())).context("PR_CAPBSET_DROP error")?,
     }
 }
 
@@ -27,16 +26,13 @@ pub fn has_cap(cap: Capability) -> Result<bool> {
     match ret {
         0 => Ok(false),
         1 => Ok(true),
-        _ => {
-            Err(Error::from_kind(ErrorKind::Sys(errno::errno()))
-                .chain_err(|| "PR_CAPBSET_READ error"))
-        }
+        _ => Err(Error::Sys(errno::errno())).context("PR_CAPBSET_READ error")?,
     }
 }
 
-pub fn read() -> Result<super::CapsHashSet> {
-    let mut res = super::CapsHashSet::new();
-    for c in super::all() {
+pub fn read() -> Result<CapsHashSet> {
+    let mut res = CapsHashSet::new();
+    for c in all() {
         if has_cap(c)? {
             res.insert(c);
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
 //! Error handling.
 
-use errno;
+use error_chain::error_chain;
 
 error_chain! {
     errors {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,26 +1,16 @@
 //! Error handling.
 
-use error_chain::error_chain;
+use failure::Fail;
 
-error_chain! {
-    errors {
-        /// Parsing error due to invalid capability name.
-        InvalidCapName(name: String) {
-            description("invalid capability name")
-            display("invalid capability name: '{}'", name)
-        }
-        /// Syscall error, as `errno(3)`.
-        Sys(errno: errno::Errno) {
-            description("syscall failed")
-            display("{}", errno)
-        }
-    }
-}
+pub type Result<T> = core::result::Result<T, failure::Error>;
 
-#[test]
-fn test_sys_errno() {
-    let eperm = errno::Errno(1);
-    let err = ErrorKind::Sys(eperm);
-    assert!(err.description().contains("syscall failed"));
-    assert!(format!("{}", err).contains("Operation not permitted"));
+#[derive(Debug, Fail)]
+pub enum Error {
+    /// Parsing error due to invalid capability name.
+    #[fail(display = "invalid capability name: '{}'", _0)]
+    InvalidCapName(String),
+
+    /// Syscall error, as `errno(3)`.
+    #[fail(display = "syscall failed with '{}'", _0)]
+    Sys(errno::Errno),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,20 +211,20 @@ impl std::str::FromStr for Capability {
             "CAP_WAKE_ALARM" => Ok(Capability::CAP_WAKE_ALARM),
             "CAP_BLOCK_SUSPEND" => Ok(Capability::CAP_BLOCK_SUSPEND),
             "CAP_AUDIT_READ" => Ok(Capability::CAP_AUDIT_READ),
-            _ => Err(Error::InvalidCapName(s.to_string()))?,
+            _ => Err(Error::InvalidCapName(s.to_string()).into()),
         }
     }
 }
 
 impl Capability {
     /// Returns the bitmask corresponding to this capability value.
-    #[cfg_attr(feature = "cargo-clippy", allow(trivially_copy_pass_by_ref))]
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::trivially_copy_pass_by_ref))]
     pub fn bitmask(&self) -> u64 {
         1u64 << (*self as u8)
     }
 
     /// Returns the index of this capability, i.e. its kernel-defined value.
-    #[cfg_attr(feature = "cargo-clippy", allow(trivially_copy_pass_by_ref))]
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::trivially_copy_pass_by_ref))]
     pub fn index(&self) -> u8 {
         (*self as u8)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,6 @@
 //! }
 //! ```
 
-#[macro_use]
-extern crate error_chain;
-extern crate errno;
-extern crate libc;
-
 mod ambient; // Implementation of Ambient set
 mod base; // Implementation of POSIX sets
 mod bounding; // Implementation of Bounding set
@@ -31,6 +26,7 @@ mod nr; // All kernel-related constants
 pub mod runtime; // Features/legacy detection at runtime
 pub mod securebits; // Thread security bits
 
+use error_chain::bail;
 use errors::*;
 use std::iter::FromIterator;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,7 @@ pub fn read(tid: Option<i32>, cset: CapSet) -> Result<CapsHashSet> {
 /// If `tid` is `None`, this operates on current thread (tid=0).
 /// It cannot manipulate Ambient set of other processes.
 /// Capabilities cannot be set in Bounding set.
-pub fn set(tid: Option<i32>, cset: CapSet, value: CapsHashSet) -> Result<()> {
+pub fn set(tid: Option<i32>, cset: CapSet, value: &CapsHashSet) -> Result<()> {
     let t = tid.unwrap_or(0);
     match cset {
         CapSet::Ambient if t == 0 => ambient::set(&value),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -6,7 +6,7 @@
 //! running kernel.
 
 use super::{ambient, CapSet, Capability, CapsHashSet};
-use errors::*;
+use crate::errors::*;
 
 /// Check whether the running kernel supports the ambient set.
 ///

--- a/src/securebits.rs
+++ b/src/securebits.rs
@@ -4,6 +4,8 @@
 //! flags, which can be used to disable special handling of capabilities
 //! for UID 0 (root).
 
+use failure::ResultExt;
+
 use crate::errors::*;
 use crate::nr;
 
@@ -13,10 +15,7 @@ pub fn has_keepcaps() -> Result<bool> {
     match ret {
         0 => Ok(false),
         1 => Ok(true),
-        _ => {
-            Err(Error::from_kind(ErrorKind::Sys(errno::errno()))
-                .chain_err(|| "PR_GET_KEEPCAPS error"))
-        }
+        _ => Err(Error::Sys(errno::errno())).context("PR_GET_KEEPCAPS error")?,
     }
 }
 
@@ -26,9 +25,6 @@ pub fn set_keepcaps(keep_caps: bool) -> Result<()> {
     let ret = unsafe { libc::prctl(nr::PR_SET_KEEPCAPS, flag, 0, 0) };
     match ret {
         0 => Ok(()),
-        _ => {
-            Err(Error::from_kind(ErrorKind::Sys(errno::errno()))
-                .chain_err(|| "PR_SET_KEEPCAPS error"))
-        }
+        _ => Err(Error::Sys(errno::errno())).context("PR_SET_KEEPCAPS error")?,
     }
 }

--- a/src/securebits.rs
+++ b/src/securebits.rs
@@ -4,11 +4,8 @@
 //! flags, which can be used to disable special handling of capabilities
 //! for UID 0 (root).
 
-use errno;
-use libc;
-
-use errors::*;
-use nr;
+use crate::errors::*;
+use crate::nr;
 
 /// Return whether the current thread's "keep capabilities" flag is set.
 pub fn has_keepcaps() -> Result<bool> {

--- a/tests/ambient.rs
+++ b/tests/ambient.rs
@@ -47,10 +47,10 @@ fn test_ambient_raise() {
 #[test]
 fn test_ambient_set() {
     let mut v = caps::CapsHashSet::new();
-    caps::set(None, caps::CapSet::Ambient, v.clone()).unwrap();
+    caps::set(None, caps::CapSet::Ambient, &v).unwrap();
     let empty = caps::read(None, caps::CapSet::Ambient).unwrap();
     assert_eq!(empty.len(), 0);
     v.insert(caps::Capability::CAP_CHOWN);
     caps::drop(None, caps::CapSet::Ambient, caps::Capability::CAP_CHOWN).unwrap();
-    assert!(caps::set(None, caps::CapSet::Ambient, v).is_err());
+    assert!(caps::set(None, caps::CapSet::Ambient, &v).is_err());
 }

--- a/tests/bounding.rs
+++ b/tests/bounding.rs
@@ -56,5 +56,5 @@ fn test_bounding_raise() {
 #[test]
 fn test_bounding_set() {
     let v = caps::CapsHashSet::new();
-    assert!(caps::set(None, caps::CapSet::Bounding, v).is_err());
+    assert!(caps::set(None, caps::CapSet::Bounding, &v).is_err());
 }

--- a/tests/effective.rs
+++ b/tests/effective.rs
@@ -39,10 +39,10 @@ fn test_effective_raise() {
 #[test]
 fn test_effective_set() {
     let mut v = caps::CapsHashSet::new();
-    caps::set(None, caps::CapSet::Effective, v.clone()).unwrap();
+    caps::set(None, caps::CapSet::Effective, &v).unwrap();
     let empty = caps::read(None, caps::CapSet::Effective).unwrap();
     assert_eq!(empty.len(), 0);
     v.insert(caps::Capability::CAP_CHOWN);
     caps::drop(None, caps::CapSet::Ambient, caps::Capability::CAP_CHOWN).unwrap();
-    assert!(caps::set(None, caps::CapSet::Ambient, v).is_err());
+    assert!(caps::set(None, caps::CapSet::Ambient, &v).is_err());
 }


### PR DESCRIPTION
- Adds an example, and changes api to borrow CapsHashSet.
- Fixes some warnings
- Upadated for 2018 edition