### PR TITLE
caps: mark enum as non-exhaustive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "caps"
-version = "0.3.5-alpha.0"
-authors = ["Luca Bruno <lucab@debian.org>"]
+version = "0.4.0-alpha.0"
+authors = ["Luca Bruno <lucab@lucabruno.net>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/lucab/caps-rs"
 documentation = "https://docs.rs/caps"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,23 +60,23 @@ pub enum CapSet {
 #[allow(non_camel_case_types)]
 #[repr(u8)]
 pub enum Capability {
-    /// CAP_CHOWN (from POSIX)
+    /// `CAP_CHOWN` (from POSIX)
     CAP_CHOWN = nr::CAP_CHOWN,
-    /// CAP_DAC_OVERRIDE (from POSIX)
+    /// `CAP_DAC_OVERRIDE` (from POSIX)
     CAP_DAC_OVERRIDE = nr::CAP_DAC_OVERRIDE,
-    /// CAP_DAC_READ_SEARCH (from POSIX)
+    /// `CAP_DAC_READ_SEARCH` (from POSIX)
     CAP_DAC_READ_SEARCH = nr::CAP_DAC_READ_SEARCH,
-    /// CAP_FOWNER (from POSIX)
+    /// `CAP_FOWNER` (from POSIX)
     CAP_FOWNER = nr::CAP_FOWNER,
-    /// CAP_FSETID (from POSIX)
+    /// `CAP_FSETID` (from POSIX)
     CAP_FSETID = nr::CAP_FSETID,
-    /// CAP_KILL (from POSIX)
+    /// `CAP_KILL` (from POSIX)
     CAP_KILL = nr::CAP_KILL,
-    /// CAP_SETGID (from POSIX)
+    /// `CAP_SETGID` (from POSIX)
     CAP_SETGID = nr::CAP_SETGID,
-    /// CAP_SETUID (from POSIX)
+    /// `CAP_SETUID` (from POSIX)
     CAP_SETUID = nr::CAP_SETUID,
-    /// CAP_SETPCAP (from Linux)
+    /// `CAP_SETPCAP` (from Linux)
     CAP_SETPCAP = nr::CAP_SETPCAP,
     CAP_LINUX_IMMUTABLE = nr::CAP_LINUX_IMMUTABLE,
     CAP_NET_BIND_SERVICE = nr::CAP_NET_BIND_SERVICE,
@@ -85,45 +85,47 @@ pub enum Capability {
     CAP_NET_RAW = nr::CAP_NET_RAW,
     CAP_IPC_LOCK = nr::CAP_IPC_LOCK,
     CAP_IPC_OWNER = nr::CAP_IPC_OWNER,
-    /// CAP_SYS_MODULE (from Linux)
+    /// `CAP_SYS_MODULE` (from Linux)
     CAP_SYS_MODULE = nr::CAP_SYS_MODULE,
-    /// CAP_SYS_RAWIO (from Linux)
+    /// `CAP_SYS_RAWIO` (from Linux)
     CAP_SYS_RAWIO = nr::CAP_SYS_RAWIO,
-    /// CAP_SYS_CHROOT (from Linux)
+    /// `CAP_SYS_CHROOT` (from Linux)
     CAP_SYS_CHROOT = nr::CAP_SYS_CHROOT,
-    /// CAP_SYS_PTRACE (from Linux)
+    /// `CAP_SYS_PTRACE` (from Linux)
     CAP_SYS_PTRACE = nr::CAP_SYS_PTRACE,
-    /// CAP_SYS_PACCT (from Linux)
+    /// `CAP_SYS_PACCT` (from Linux)
     CAP_SYS_PACCT = nr::CAP_SYS_PACCT,
-    /// CAP_SYS_ADMIN (from Linux)
+    /// `CAP_SYS_ADMIN` (from Linux)
     CAP_SYS_ADMIN = nr::CAP_SYS_ADMIN,
-    /// CAP_SYS_BOOT (from Linux)
+    /// `CAP_SYS_BOOT` (from Linux)
     CAP_SYS_BOOT = nr::CAP_SYS_BOOT,
-    /// CAP_SYS_NICE (from Linux)
+    /// `CAP_SYS_NICE` (from Linux)
     CAP_SYS_NICE = nr::CAP_SYS_NICE,
-    /// CAP_SYS_RESOURCE (from Linux)
+    /// `CAP_SYS_RESOURCE` (from Linux)
     CAP_SYS_RESOURCE = nr::CAP_SYS_RESOURCE,
-    /// CAP_SYS_TIME (from Linux)
+    /// `CAP_SYS_TIME` (from Linux)
     CAP_SYS_TIME = nr::CAP_SYS_TIME,
-    /// CAP_SYS_TTY_CONFIG (from Linux)
+    /// `CAP_SYS_TTY_CONFIG` (from Linux)
     CAP_SYS_TTY_CONFIG = nr::CAP_SYS_TTY_CONFIG,
-    /// CAP_SYS_MKNOD (from Linux 2.4)
+    /// `CAP_SYS_MKNOD` (from Linux, >= 2.4)
     CAP_MKNOD = nr::CAP_MKNOD,
-    /// CAP_LEASE (from Linux 2.4)
+    /// `CAP_LEASE` (from Linux, >= 2.4)
     CAP_LEASE = nr::CAP_LEASE,
     CAP_AUDIT_WRITE = nr::CAP_AUDIT_WRITE,
-    /// CAP_AUDIT_CONTROL (from Linux 2.6.11)
+    /// `CAP_AUDIT_CONTROL` (from Linux, >= 2.6.11)
     CAP_AUDIT_CONTROL = nr::CAP_AUDIT_CONTROL,
     CAP_SETFCAP = nr::CAP_SETFCAP,
     CAP_MAC_OVERRIDE = nr::CAP_MAC_OVERRIDE,
     CAP_MAC_ADMIN = nr::CAP_MAC_ADMIN,
-    /// CAP_SYSLOG (from Linux 2.6.37)
+    /// `CAP_SYSLOG` (from Linux, >= 2.6.37)
     CAP_SYSLOG = nr::CAP_SYSLOG,
-    // CAP_WAKE_ALARM (from Linux 3.0)
+    /// `CAP_WAKE_ALARM` (from Linux, >= 3.0)
     CAP_WAKE_ALARM = nr::CAP_WAKE_ALARM,
     CAP_BLOCK_SUSPEND = nr::CAP_BLOCK_SUSPEND,
-    /// CAP_AUDIT_READ (from Linux 3.16).
+    /// `CAP_AUDIT_READ` (from Linux, >= 3.16).
     CAP_AUDIT_READ = nr::CAP_AUDIT_READ,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 impl std::fmt::Display for Capability {
@@ -167,6 +169,7 @@ impl std::fmt::Display for Capability {
             Capability::CAP_WAKE_ALARM => "CAP_WAKE_ALARM",
             Capability::CAP_BLOCK_SUSPEND => "CAP_BLOCK_SUSPEND",
             Capability::CAP_AUDIT_READ => "CAP_AUDIT_READ",
+            Capability::__Nonexhaustive => unreachable!("invalid capability"),
         };
         write!(f, "{}", name)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,7 @@ pub fn drop(tid: Option<i32>, cset: CapSet, cap: Capability) -> Result<()> {
     }
 }
 
-/// Return an `HashSet` with all known capabilities.
+/// Return the set of all capabilities supported by this library.
 pub fn all() -> CapsHashSet {
     let slice = vec![
         Capability::CAP_CHOWN,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ impl Capability {
     /// Returns the index of this capability, i.e. its kernel-defined value.
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn index(&self) -> u8 {
-        (*self as u8)
+        *self as u8
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -18,7 +18,7 @@ pub fn ambient_set_supported() -> Result<()> {
     Ok(())
 }
 
-/// Return an `HashSet` with all capabilities supported by the running kernel.
+/// Return the set of all capabilities supported on the current thread.
 pub fn all_supported() -> CapsHashSet {
     let mut supported = super::all();
     for c in super::all() {


### PR DESCRIPTION
This marks the `Capability` enum as non-exhaustive, as the Linux kernel is adding more capabilities.