### PR TITLE
errors: switch to thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ exclude = [
 ]
 
 [dependencies]
-errno = "0.2"
-error-chain = {version = "0.12", default-features = false}
-libc = "0.2"
+errno = "^0.2"
+thiserror = "^1.0"
+libc = "^0.2"
 
 [package.metadata.release]
 sign-commit = true

--- a/src/bounding.rs
+++ b/src/bounding.rs
@@ -1,8 +1,8 @@
-use crate::errors::*;
+use crate::errors::CapsError;
 use crate::nr;
 use crate::Capability;
 
-pub fn clear() -> Result<()> {
+pub fn clear() -> Result<(), CapsError> {
     for c in super::all() {
         if has_cap(c)? {
             drop(c)?;
@@ -11,30 +11,30 @@ pub fn clear() -> Result<()> {
     Ok(())
 }
 
-pub fn drop(cap: Capability) -> Result<()> {
+pub fn drop(cap: Capability) -> Result<(), CapsError> {
     let ret = unsafe { libc::prctl(nr::PR_CAPBSET_DROP, libc::c_uint::from(cap.index()), 0, 0) };
     match ret {
         0 => Ok(()),
-        _ => {
-            Err(Error::from_kind(ErrorKind::Sys(errno::errno()))
-                .chain_err(|| "PR_CAPBSET_DROP error"))
-        }
+        _ => Err(CapsError::from(format!(
+            "PR_CAPBSET_READ failure, errno {}",
+            errno::errno()
+        ))),
     }
 }
 
-pub fn has_cap(cap: Capability) -> Result<bool> {
+pub fn has_cap(cap: Capability) -> Result<bool, CapsError> {
     let ret = unsafe { libc::prctl(nr::PR_CAPBSET_READ, libc::c_uint::from(cap.index()), 0, 0) };
     match ret {
         0 => Ok(false),
         1 => Ok(true),
-        _ => {
-            Err(Error::from_kind(ErrorKind::Sys(errno::errno()))
-                .chain_err(|| "PR_CAPBSET_READ error"))
-        }
+        _ => Err(CapsError::from(format!(
+            "PR_CAPBSET_READ failure, errno {}",
+            errno::errno()
+        ))),
     }
 }
 
-pub fn read() -> Result<super::CapsHashSet> {
+pub fn read() -> Result<super::CapsHashSet, CapsError> {
     let mut res = super::CapsHashSet::new();
     for c in super::all() {
         if has_cap(c)? {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,28 +1,20 @@
 //! Error handling.
 
-error_chain! {
-    errors {
-        /// Parsing error due to invalid capability name.
-        InvalidCapName(name: String) {
-            description("invalid capability name")
-            display("invalid capability name: '{}'", name)
-        }
-        /// Syscall error, as `errno(3)`.
-        Sys(errno: errno::Errno) {
-            description("syscall failed")
-            display("{}", errno)
-        }
-    }
-    foreign_links {
-        Io(std::io::Error);
-        ParseInt(std::num::ParseIntError);
+use thiserror::Error;
+
+/// Library errors.
+#[derive(Error, Debug)]
+#[error("caps error: {0}")]
+pub struct CapsError(pub(crate) String);
+
+impl From<&str> for CapsError {
+    fn from(arg: &str) -> Self {
+        Self(arg.to_string())
     }
 }
 
-#[test]
-fn test_sys_errno() {
-    let eperm = errno::Errno(1);
-    let err = ErrorKind::Sys(eperm);
-    assert!(err.description().contains("syscall failed"));
-    assert!(format!("{}", err).contains("Operation not permitted"));
+impl From<String> for CapsError {
+    fn from(arg: String) -> Self {
+        Self(arg)
+    }
 }

--- a/src/securebits.rs
+++ b/src/securebits.rs
@@ -4,31 +4,31 @@
 //! flags, which can be used to disable special handling of capabilities
 //! for UID 0 (root).
 
-use crate::errors::*;
+use crate::errors::CapsError;
 use crate::nr;
 
 /// Return whether the current thread's "keep capabilities" flag is set.
-pub fn has_keepcaps() -> Result<bool> {
+pub fn has_keepcaps() -> Result<bool, CapsError> {
     let ret = unsafe { libc::prctl(nr::PR_GET_KEEPCAPS, 0, 0, 0) };
     match ret {
         0 => Ok(false),
         1 => Ok(true),
-        _ => {
-            Err(Error::from_kind(ErrorKind::Sys(errno::errno()))
-                .chain_err(|| "PR_GET_KEEPCAPS error"))
-        }
+        _ => Err(CapsError::from(format!(
+            "PR_GET_KEEPCAPS failure, errno {}",
+            errno::errno()
+        ))),
     }
 }
 
 /// Set the value of the current thread's "keep capabilities" flag.
-pub fn set_keepcaps(keep_caps: bool) -> Result<()> {
+pub fn set_keepcaps(keep_caps: bool) -> Result<(), CapsError> {
     let flag = if keep_caps { 1 } else { 0 };
     let ret = unsafe { libc::prctl(nr::PR_SET_KEEPCAPS, flag, 0, 0) };
     match ret {
         0 => Ok(()),
-        _ => {
-            Err(Error::from_kind(ErrorKind::Sys(errno::errno()))
-                .chain_err(|| "PR_SET_KEEPCAPS error"))
-        }
+        _ => Err(CapsError::from(format!(
+            "PR_SET_KEEPCAPS failure, errno {}",
+            errno::errno()
+        ))),
     }
 }


### PR DESCRIPTION
This switches error handling logic from the `error_chain` library
to `thiserror`.