### PR TITLE
lib: switch 'set' to borrow its argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ os: linux
 dist: bionic
 
 jobs:
+  fast_finish: true
   allow_failures:
     - rust: nightly
+    - arch: ppc64le
   include:
     - name: "Test with nightly toolchain"
       arch: amd64
@@ -22,12 +24,11 @@ jobs:
       rust: stable
       script:
         - cargo test
-# Builders temporarily unavailable, enable this later on.
-#    - name: "Test with stable toolchain on aarch64"
-#      arch: arm64
-#      rust: stable
-#      script:
-#        - cargo test
+    - name: "Test with stable toolchain on aarch64"
+      arch: arm64
+      rust: stable
+      script:
+        - cargo test
     - name: "Test with stable toolchain on ppc64le"
       arch: ppc64le
       rust: stable

--- a/README.md
+++ b/README.md
@@ -23,35 +23,38 @@ This library tries to achieve the following goals:
 ## Example
 
 ```rust
-use caps::{Capability, CapSet};
+type ExResult<T> = Result<T, Box<dyn std::error::Error + 'static>>;
 
-fn manipulate_caps() {
+fn manipulate_caps() -> ExResult<()> {
+    use caps::{Capability, CapSet};
+
     // Retrieve permitted set.
-    let cur = caps::read(None, CapSet::Permitted).unwrap();
+    let cur = caps::read(None, CapSet::Permitted)?;
     println!("Current permitted caps: {:?}.", cur);
     
     // Retrieve effective set.
-    let cur = caps::read(None, CapSet::Effective).unwrap();
+    let cur = caps::read(None, CapSet::Effective)?;
     println!("Current effective caps: {:?}.", cur);
     
     // Check if CAP_CHOWN is in permitted set.
-    let perm_chown = caps::has_cap(None, CapSet::Permitted, Capability::CAP_CHOWN).unwrap();
-    if !perm_chown.unwrap() {
-        println!("Try running this as root!");
-        return;
+    let perm_chown = caps::has_cap(None, CapSet::Permitted, Capability::CAP_CHOWN)?;
+    if !perm_chown {
+        return Err("Try running this as root!".into());
     }
 
     // Clear all effective caps.
-    caps::clear(None, CapSet::Effective).unwrap();
+    caps::clear(None, CapSet::Effective)?;
     println!("Cleared effective caps.");
-    let cur = caps::read(None, CapSet::Effective).unwrap();
+    let cur = caps::read(None, CapSet::Effective)?;
     println!("Current effective caps: {:?}.", cur);
 
     // Since `CAP_CHOWN` is still in permitted, it can be raised again.
-    caps::raise(None, CapSet::Effective, Capability::CAP_CHOWN).unwrap();
+    caps::raise(None, CapSet::Effective, Capability::CAP_CHOWN)?;
     println!("Raised CAP_CHOWN in effective set.");
-    let cur = caps::read(None, CapSet::Effective).unwrap();
+    let cur = caps::read(None, CapSet::Effective)?;
     println!("Current effective caps: {:?}.", cur);
+
+    Ok(())
 }
 ```
 

--- a/examples/clear_permitted.rs
+++ b/examples/clear_permitted.rs
@@ -3,53 +3,56 @@
 //! It clears Permitted set to show its interaction
 //! with Effective set.
 //!
-//! This is a caps example ONLY: do NOT panic/unwrap/assert
+//! This is an example ONLY: do NOT panic/unwrap/assert
 //! in production code!
 
-extern crate caps;
+type ExResult<T> = Result<T, Box<dyn std::error::Error + 'static>>;
 
-use caps::{CapSet, Capability};
+fn main() -> ExResult<()> {
+    use caps::{CapSet, Capability};
 
-fn main() {
     // Check if `CAP_CHOWN` was originally available.
-    let cur = caps::read(None, CapSet::Permitted).unwrap();
+    let cur = caps::read(None, CapSet::Permitted)?;
     println!("-> Current permitted caps: {:?}.", cur);
-    let cur = caps::read(None, CapSet::Effective).unwrap();
+    let cur = caps::read(None, CapSet::Effective)?;
     println!("-> Current effective caps: {:?}.", cur);
     let perm_chown = caps::has_cap(None, CapSet::Permitted, Capability::CAP_CHOWN);
     assert!(perm_chown.is_ok());
-    if !perm_chown.unwrap() {
-        println!("Try running this again as root/sudo or with CAP_CHOWN file capability!");
-        return;
+    if !perm_chown? {
+        return Err(
+            "Try running this again as root/sudo or with CAP_CHOWN file capability!".into(),
+        );
     }
 
     // Clear all effective caps.
     let r = caps::clear(None, CapSet::Effective);
     assert!(r.is_ok());
     println!("Cleared effective caps.");
-    let cur = caps::read(None, CapSet::Effective).unwrap();
+    let cur = caps::read(None, CapSet::Effective)?;
     println!("-> Current effective caps: {:?}.", cur);
 
     // Since `CAP_CHOWN` is still in permitted, it can be raised again.
     let r = caps::raise(None, CapSet::Effective, Capability::CAP_CHOWN);
     assert!(r.is_ok());
     println!("Raised CAP_CHOWN in effective set.");
-    let cur = caps::read(None, CapSet::Effective).unwrap();
+    let cur = caps::read(None, CapSet::Effective)?;
     println!("-> Current effective caps: {:?}.", cur);
 
     // Clearing Permitted also impacts effective.
     let r = caps::clear(None, CapSet::Permitted);
     assert!(r.is_ok());
     println!("Cleared permitted caps.");
-    let cur = caps::read(None, CapSet::Permitted).unwrap();
+    let cur = caps::read(None, CapSet::Permitted)?;
     println!("-> Current permitted caps: {:?}.", cur);
-    let cur = caps::read(None, CapSet::Effective).unwrap();
+    let cur = caps::read(None, CapSet::Effective)?;
     println!("-> Current effective caps: {:?}.", cur);
 
     // Trying to raise `CAP_CHOWN` now fails.
     let r = caps::raise(None, CapSet::Effective, Capability::CAP_CHOWN);
     assert!(r.is_err());
     println!("Tried to raise CAP_CHOWN but failed.");
-    let cur = caps::read(None, CapSet::Effective).unwrap();
+    let cur = caps::read(None, CapSet::Effective)?;
     println!("-> Current effective caps: {:?}.", cur);
+
+    Ok(())
 }

--- a/examples/legacy.rs
+++ b/examples/legacy.rs
@@ -1,5 +1,3 @@
-extern crate caps;
-
 use caps::runtime;
 
 fn main() {

--- a/examples/manipulate_sys_nice.rs
+++ b/examples/manipulate_sys_nice.rs
@@ -3,15 +3,14 @@
 //! It drops and raises `CAP_SYS_NICE` to show its interaction
 //! with `getpriority(2)`.
 //!
-//! This is a caps example ONLY: do NOT panic/unwrap/assert
+//! This is an example ONLY: do NOT panic/unwrap/assert
 //! in production code!
 
-extern crate caps;
-extern crate libc;
+type ExResult<T> = Result<T, Box<dyn std::error::Error + 'static>>;
 
-use caps::{CapSet, Capability};
+fn main() -> ExResult<()> {
+    use caps::{CapSet, Capability};
 
-fn main() {
     // Any process can lower its own priority.
     println!("-> Current process priority is {}.", proc_nice());
     let r = renice(19);
@@ -25,7 +24,7 @@ fn main() {
     println!("Dropped CAP_SYS_NICE.");
     let has_sys_nice = caps::has_cap(None, CapSet::Effective, Capability::CAP_SYS_NICE);
     assert!(has_sys_nice.is_ok());
-    assert_eq!(has_sys_nice.unwrap(), false);
+    assert_eq!(has_sys_nice.unwrap_or(true), false);
     let r = renice(-20);
     assert_eq!(r, -1);
     println!("Unprivileged, unable to raise priority to -20.");
@@ -33,9 +32,10 @@ fn main() {
     // If `CAP_SYS_NICE` is still in permitted set, it can be raised again.
     let perm_sys_nice = caps::has_cap(None, CapSet::Permitted, Capability::CAP_SYS_NICE);
     assert!(perm_sys_nice.is_ok());
-    if !perm_sys_nice.unwrap() {
-        println!("Try running this again as root/sudo or with CAP_SYS_NICE file capability!");
-        return;
+    if !perm_sys_nice? {
+        return Err(
+            "Try running this again as root/sudo or with CAP_SYS_NICE file capability!".into(),
+        );
     }
     let r = caps::raise(None, CapSet::Effective, Capability::CAP_SYS_NICE);
     assert!(r.is_ok());
@@ -46,6 +46,8 @@ fn main() {
     assert_eq!(r, 0);
     println!("Privileged, raised priority to -20.");
     println!("-> Current process priority is {}.", proc_nice());
+
+    Ok(())
 }
 
 #[cfg(target_env = "musl")]
@@ -54,12 +56,12 @@ const PRIO_PROCESS: i32 = libc::PRIO_PROCESS;
 const PRIO_PROCESS: u32 = libc::PRIO_PROCESS as u32;
 
 fn renice(prio: libc::c_int) -> libc::c_int {
-    // This is not proper logic, as it does not drain errno.
+    // This is not proper logic, as it does not record errno value on error.
     unsafe { libc::setpriority(PRIO_PROCESS, 0, prio) }
 }
 
 fn proc_nice() -> libc::c_int {
-    // This is not proper logic, as it does not special-case -1 nor drain errno.
+    // This is not proper logic, as it does not special-case -1 nor record errno.
     let r = unsafe { libc::getpriority(PRIO_PROCESS as u32, 0) };
     if r == -1 {
         panic!("getpriority failed.");

--- a/examples/parse.rs
+++ b/examples/parse.rs
@@ -1,5 +1,3 @@
-extern crate caps;
-
 use caps::Capability;
 use std::str::FromStr;
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -82,7 +82,7 @@ pub fn read(tid: i32, cset: CapSet) -> Result<CapsHashSet, CapsError> {
         CapSet::Permitted => (u64::from(data.permitted_s1) << 32) + u64::from(data.permitted_s0),
         CapSet::Bounding | CapSet::Ambient => return Err("not a base set".into()),
     };
-    let mut res = super::CapsHashSet::new();
+    let mut res = CapsHashSet::new();
     for c in super::all() {
         if (caps & c.bitmask()) != 0 {
             res.insert(c);

--- a/src/base.rs
+++ b/src/base.rs
@@ -91,7 +91,7 @@ pub fn read(tid: i32, cset: CapSet) -> Result<CapsHashSet, CapsError> {
     Ok(res)
 }
 
-pub fn set(tid: i32, cset: CapSet, value: super::CapsHashSet) -> Result<(), CapsError> {
+pub fn set(tid: i32, cset: CapSet, value: &CapsHashSet) -> Result<(), CapsError> {
     let mut hdr = CapUserHeader {
         version: CAPS_V3,
         pid: tid,
@@ -126,7 +126,7 @@ pub fn set(tid: i32, cset: CapSet, value: super::CapsHashSet) -> Result<(), Caps
 pub fn drop(tid: i32, cset: CapSet, cap: Capability) -> Result<(), CapsError> {
     let mut caps = read(tid, cset)?;
     if caps.remove(&cap) {
-        set(tid, cset, caps)?;
+        set(tid, cset, &caps)?;
     };
     Ok(())
 }
@@ -134,7 +134,7 @@ pub fn drop(tid: i32, cset: CapSet, cap: Capability) -> Result<(), CapsError> {
 pub fn raise(tid: i32, cset: CapSet, cap: Capability) -> Result<(), CapsError> {
     let mut caps = read(tid, cset)?;
     if caps.insert(cap) {
-        set(tid, cset, caps)?;
+        set(tid, cset, &caps)?;
     };
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,33 +1,42 @@
-//! A pure-Rust library to work with Linux capabilities.
-//!
-//! It provides support for manipulating capabilities available
-//! in modern Linux kernel. It supports traditional POSIX sets
-//! (Effective, Inheritable, Permitted) as well as Linux-specific
-//! Ambient and Bounding capabilities sets.
-//!
-//! ```rust
-//! use caps::{Capability, CapSet};
-//!
-//! fn manipulate_caps() {
-//!     if caps::has_cap(None, CapSet::Permitted, Capability::CAP_SYS_NICE).unwrap() {
-//!         caps::drop(None, CapSet::Effective, Capability::CAP_SYS_NICE).unwrap();
-//!         let s = caps::read(None, CapSet::Effective).unwrap();
-//!         assert_eq!(s.contains(&Capability::CAP_SYS_NICE), false);
-//!         caps::clear(None, CapSet::Effective).unwrap();
-//!     };
-//! }
-//! ```
+/*!
+A pure-Rust library to work with Linux capabilities.
+
+It provides support for manipulating capabilities available on modern Linux
+kernels. It supports traditional POSIX sets (Effective, Inheritable, Permitted)
+as well as Linux-specific Ambient and Bounding capabilities sets.
+
+```rust
+type ExResult<T> = Result<T, Box<dyn std::error::Error + 'static>>;
+
+fn manipulate_caps() -> ExResult<()> {
+    use caps::{Capability, CapSet};
+
+    if caps::has_cap(None, CapSet::Permitted, Capability::CAP_SYS_NICE)? {
+        caps::drop(None, CapSet::Effective, Capability::CAP_SYS_NICE)?;
+        let effective = caps::read(None, CapSet::Effective)?;
+        assert_eq!(effective.contains(&Capability::CAP_SYS_NICE), false);
+
+        caps::clear(None, CapSet::Effective)?;
+        let cleared = caps::read(None, CapSet::Effective)?;
+        assert_eq!(cleared.is_empty(), true);
+    };
+
+    Ok(())
+}
+```
+!*/
 
 pub mod errors;
 pub mod runtime;
 pub mod securebits;
 
+// Implementation of Bounding set.
 mod ambient;
-// Implementation of POSIX sets
+// Implementation of POSIX sets.
 mod base;
-// Implementation of Bounding set
+// Implementation of Bounding set.
 mod bounding;
-// All kernel-related constants
+// All kernel-related constants.
 mod nr;
 
 use crate::errors::CapsError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,10 +275,10 @@ pub fn read(tid: Option<i32>, cset: CapSet) -> Result<CapsHashSet, CapsError> {
 /// If `tid` is `None`, this operates on current thread (tid=0).
 /// It cannot manipulate Ambient set of other processes.
 /// Capabilities cannot be set in Bounding set.
-pub fn set(tid: Option<i32>, cset: CapSet, value: CapsHashSet) -> Result<(), CapsError> {
+pub fn set(tid: Option<i32>, cset: CapSet, value: &CapsHashSet) -> Result<(), CapsError> {
     let t = tid.unwrap_or(0);
     match cset {
-        CapSet::Ambient if t == 0 => ambient::set(&value),
+        CapSet::Ambient if t == 0 => ambient::set(value),
         CapSet::Effective | CapSet::Inheritable | CapSet::Permitted => base::set(t, cset, value),
         _ => Err("operation not supported".into()),
     }

--- a/tests/ambient.rs
+++ b/tests/ambient.rs
@@ -1,5 +1,3 @@
-extern crate caps;
-
 #[test]
 fn test_ambient_has_cap() {
     caps::has_cap(None, caps::CapSet::Ambient, caps::Capability::CAP_CHOWN).unwrap();

--- a/tests/ambient.rs
+++ b/tests/ambient.rs
@@ -47,10 +47,10 @@ fn test_ambient_raise() {
 #[test]
 fn test_ambient_set() {
     let mut v = caps::CapsHashSet::new();
-    caps::set(None, caps::CapSet::Ambient, v.clone()).unwrap();
+    caps::set(None, caps::CapSet::Ambient, &v).unwrap();
     let empty = caps::read(None, caps::CapSet::Ambient).unwrap();
     assert_eq!(empty.len(), 0);
     v.insert(caps::Capability::CAP_CHOWN);
     caps::drop(None, caps::CapSet::Ambient, caps::Capability::CAP_CHOWN).unwrap();
-    assert!(caps::set(None, caps::CapSet::Ambient, v).is_err());
+    assert!(caps::set(None, caps::CapSet::Ambient, &v).is_err());
 }

--- a/tests/bounding.rs
+++ b/tests/bounding.rs
@@ -1,5 +1,3 @@
-extern crate caps;
-
 #[test]
 fn test_bounding_has_cap() {
     caps::has_cap(

--- a/tests/bounding.rs
+++ b/tests/bounding.rs
@@ -56,5 +56,5 @@ fn test_bounding_raise() {
 #[test]
 fn test_bounding_set() {
     let v = caps::CapsHashSet::new();
-    assert!(caps::set(None, caps::CapSet::Bounding, v).is_err());
+    assert!(caps::set(None, caps::CapSet::Bounding, &v).is_err());
 }

--- a/tests/effective.rs
+++ b/tests/effective.rs
@@ -39,10 +39,10 @@ fn test_effective_raise() {
 #[test]
 fn test_effective_set() {
     let mut v = caps::CapsHashSet::new();
-    caps::set(None, caps::CapSet::Effective, v.clone()).unwrap();
+    caps::set(None, caps::CapSet::Effective, &v).unwrap();
     let empty = caps::read(None, caps::CapSet::Effective).unwrap();
     assert_eq!(empty.len(), 0);
     v.insert(caps::Capability::CAP_CHOWN);
     caps::drop(None, caps::CapSet::Ambient, caps::Capability::CAP_CHOWN).unwrap();
-    assert!(caps::set(None, caps::CapSet::Ambient, v).is_err());
+    assert!(caps::set(None, caps::CapSet::Ambient, &v).is_err());
 }

--- a/tests/effective.rs
+++ b/tests/effective.rs
@@ -1,5 +1,3 @@
-extern crate caps;
-
 #[test]
 fn test_effective_has_cap() {
     caps::has_cap(None, caps::CapSet::Effective, caps::Capability::CAP_CHOWN).unwrap();

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1,4 +1,3 @@
-extern crate caps;
 use caps::runtime;
 
 #[test]

--- a/tests/securebits.rs
+++ b/tests/securebits.rs
@@ -1,4 +1,3 @@
-extern crate caps;
 use caps::securebits;
 
 #[test]


### PR DESCRIPTION
This changes `caps::set()` signature to borrow its `CapsHashSet` argument instead of taking ownership of it.