### PR TITLE
cargo: caps release 0.4.0-alpha.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caps"
-version = "0.4.0-alpha.0"
+version = "0.4.0-alpha.1"
 edition = "2018"
 authors = ["Luca Bruno <lucab@lucabruno.net>"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
Changes:
 * lib: switch 'set' to borrow its argument
 * errors: switch to thiserror
 * ci: test on multiple architectures
 * cargo: switch to edition 2018
 * runtime: support procfs cap_last_cap
 * caps: mark enum as non-exhaustive
 * ci: bump toolchains
 * caps: fix warnings