### PR TITLE
caps: gracefully support older kernel versions

### DIFF
--- a/src/ambient.rs
+++ b/src/ambient.rs
@@ -2,6 +2,7 @@
 
 use crate::errors::CapsError;
 use crate::nr;
+use crate::runtime;
 use crate::{Capability, CapsHashSet};
 
 pub fn clear() -> Result<(), CapsError> {
@@ -63,7 +64,7 @@ pub fn raise(cap: Capability) -> Result<(), CapsError> {
 
 pub fn read() -> Result<CapsHashSet, CapsError> {
     let mut res = super::CapsHashSet::new();
-    for c in super::all() {
+    for c in runtime::thread_all_supported() {
         if has_cap(c)? {
             res.insert(c);
         }
@@ -72,7 +73,7 @@ pub fn read() -> Result<CapsHashSet, CapsError> {
 }
 
 pub fn set(value: &super::CapsHashSet) -> Result<(), CapsError> {
-    for c in super::all() {
+    for c in runtime::thread_all_supported() {
         if value.contains(&c) {
             raise(c)?;
         } else {

--- a/src/bounding.rs
+++ b/src/bounding.rs
@@ -1,5 +1,6 @@
 use crate::errors::CapsError;
 use crate::nr;
+use crate::runtime;
 use crate::Capability;
 
 pub fn clear() -> Result<(), CapsError> {
@@ -36,7 +37,7 @@ pub fn has_cap(cap: Capability) -> Result<bool, CapsError> {
 
 pub fn read() -> Result<super::CapsHashSet, CapsError> {
     let mut res = super::CapsHashSet::new();
-    for c in super::all() {
+    for c in runtime::thread_all_supported() {
         if has_cap(c)? {
             res.insert(c);
         }

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -7,7 +7,8 @@ fn test_ambient_supported() {
 
 #[test]
 fn test_thread_all_supported() {
-    assert_eq!(runtime::thread_all_supported(), caps::all());
+    assert!(runtime::thread_all_supported().len() > 0);
+    assert!(runtime::thread_all_supported().len() <= caps::all().len());
 }
 
 #[test]
@@ -19,17 +20,13 @@ fn test_procfs_all_supported() {
     let thread = runtime::thread_all_supported();
     let all = caps::all();
 
+    assert!(thread.len() > 0);
+    assert!(thread.len() <= all.len());
     assert_eq!(
         p1,
         p2,
         "{:?}",
         p1.symmetric_difference(&p2).collect::<Vec<_>>()
-    );
-    assert_eq!(
-        p1,
-        all,
-        "{:?}",
-        p1.symmetric_difference(&all).collect::<Vec<_>>()
     );
     assert_eq!(
         p1,


### PR DESCRIPTION
When running on older systems, the set of capabilities supported by
this library could be bigger than those effectively known by
the kernel.
This removes some library assumptions about kernel-supported
capabilities. Thus it allows manipulating the ambient and bounding
set in a graceful way, relying on runtime introspection.