### PR TITLE
nr: add CAP_PERFMON and CAP_BPF

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,8 @@ pub enum Capability {
     CAP_AUDIT_READ = nr::CAP_AUDIT_READ,
     /// `CAP_PERFMON` (from Linux, >= 5.8).
     CAP_PERFMON = nr::CAP_PERFMON,
+    /// `CAP_BPF` (from Linux, >= 5.8).
+    CAP_BPF = nr::CAP_BPF,
     #[doc(hidden)]
     __Nonexhaustive,
 }
@@ -180,6 +182,7 @@ impl std::fmt::Display for Capability {
             Capability::CAP_BLOCK_SUSPEND => "CAP_BLOCK_SUSPEND",
             Capability::CAP_AUDIT_READ => "CAP_AUDIT_READ",
             Capability::CAP_PERFMON => "CAP_PERFMON",
+            Capability::CAP_BPF => "CAP_BPF",
             Capability::__Nonexhaustive => unreachable!("invalid capability"),
         };
         write!(f, "{}", name)
@@ -230,6 +233,7 @@ impl std::str::FromStr for Capability {
             "CAP_BLOCK_SUSPEND" => Ok(Capability::CAP_BLOCK_SUSPEND),
             "CAP_AUDIT_READ" => Ok(Capability::CAP_AUDIT_READ),
             "CAP_PERFMON" => Ok(Capability::CAP_PERFMON),
+            "CAP_BPF" => Ok(Capability::CAP_BPF),
             _ => Err(format!("invalid capability: {}", s).into()),
         }
     }
@@ -384,6 +388,7 @@ pub fn all() -> CapsHashSet {
         Capability::CAP_BLOCK_SUSPEND,
         Capability::CAP_AUDIT_READ,
         Capability::CAP_PERFMON,
+        Capability::CAP_BPF,
     ];
     CapsHashSet::from_iter(slice)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,8 @@ pub enum Capability {
     CAP_BLOCK_SUSPEND = nr::CAP_BLOCK_SUSPEND,
     /// `CAP_AUDIT_READ` (from Linux, >= 3.16).
     CAP_AUDIT_READ = nr::CAP_AUDIT_READ,
+    /// `CAP_PERFMON` (from Linux, >= 5.8).
+    CAP_PERFMON = nr::CAP_PERFMON,
     #[doc(hidden)]
     __Nonexhaustive,
 }
@@ -177,6 +179,7 @@ impl std::fmt::Display for Capability {
             Capability::CAP_WAKE_ALARM => "CAP_WAKE_ALARM",
             Capability::CAP_BLOCK_SUSPEND => "CAP_BLOCK_SUSPEND",
             Capability::CAP_AUDIT_READ => "CAP_AUDIT_READ",
+            Capability::CAP_PERFMON => "CAP_PERFMON",
             Capability::__Nonexhaustive => unreachable!("invalid capability"),
         };
         write!(f, "{}", name)
@@ -226,6 +229,7 @@ impl std::str::FromStr for Capability {
             "CAP_WAKE_ALARM" => Ok(Capability::CAP_WAKE_ALARM),
             "CAP_BLOCK_SUSPEND" => Ok(Capability::CAP_BLOCK_SUSPEND),
             "CAP_AUDIT_READ" => Ok(Capability::CAP_AUDIT_READ),
+            "CAP_PERFMON" => Ok(Capability::CAP_PERFMON),
             _ => Err(format!("invalid capability: {}", s).into()),
         }
     }
@@ -379,6 +383,7 @@ pub fn all() -> CapsHashSet {
         Capability::CAP_WAKE_ALARM,
         Capability::CAP_BLOCK_SUSPEND,
         Capability::CAP_AUDIT_READ,
+        Capability::CAP_PERFMON,
     ];
     CapsHashSet::from_iter(slice)
 }

--- a/src/nr.rs
+++ b/src/nr.rs
@@ -39,6 +39,7 @@ pub const CAP_WAKE_ALARM: u8 = 35;
 pub const CAP_BLOCK_SUSPEND: u8 = 36;
 pub const CAP_AUDIT_READ: u8 = 37;
 pub const CAP_PERFMON: u8 = 38;
+pub const CAP_BPF: u8 = 39;
 
 /* from <sys/prctl.h> */
 

--- a/src/nr.rs
+++ b/src/nr.rs
@@ -38,6 +38,7 @@ pub const CAP_SYSLOG: u8 = 34;
 pub const CAP_WAKE_ALARM: u8 = 35;
 pub const CAP_BLOCK_SUSPEND: u8 = 36;
 pub const CAP_AUDIT_READ: u8 = 37;
+pub const CAP_PERFMON: u8 = 38;
 
 /* from <sys/prctl.h> */
 


### PR DESCRIPTION
Two new capabilities (`CAP_PERFMON` and `CAP_BPF`) have been introduced in Linux 5.8:
 * https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/include/uapi/linux/capability.h?id=980737282232b752bb14dab96d77665c15889c36
 * https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/include/uapi/linux/capability.h?id=a17b53c4a4b55ec322c132b6670743612229ee9c

Closes: https://github.com/lucab/caps-rs/issues/54