### PR TITLE
cargo: caps release 0.4.0-alpha.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caps"
-version = "0.4.0-alpha.1"
+version = "0.4.0-alpha.2"
 edition = "2018"
 authors = ["Luca Bruno <lucab@lucabruno.net>"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
Changes:
 * caps: gracefully support older kernel versions
 * nr: add CAP_PERFMON and CAP_BPF