### PR TITLE
Add enum iterator in enum Capability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = [
 errno = "^0.2"
 thiserror = "^1.0"
 libc = "^0.2"
+enum-iterator = "0.6.0"
 
 [package.metadata.release]
 sign-commit = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ mod nr;
 
 use crate::errors::CapsError;
 use std::iter::FromIterator;
+use enum_iterator::IntoEnumIterator;
 
 /// Linux capabilities sets.
 ///
@@ -64,7 +65,7 @@ pub enum CapSet {
 ///
 /// All capabilities supported by Linux, including standard
 /// POSIX and custom ones. See `capabilities(7)`.
-#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
+#[derive(IntoEnumIterator, PartialEq, Eq, Hash, Debug, Clone, Copy)]
 #[allow(non_camel_case_types)]
 #[repr(u8)]
 pub enum Capability {


### PR DESCRIPTION
I want to add enum iterator in enum Capability.
This feature is useful when the program drops other than specified capabilities of the bounding set. 

If the developers set the bounding to some Capabilities they wish to enable（e.g., from the setting file), they need to drop other than the specified Capabilities.
At that time, if the enum Capability has the iterator, can traverse the enum Capability and execute the caps::drop function.