### PR TITLE
nr: add CAP_CHECKPOINT_RESTORE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caps"
-version = "0.4.1-alpha.0"
+version = "0.5.0-alpha.0"
 edition = "2018"
 authors = ["Luca Bruno <lucab@lucabruno.net>"]
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,8 @@ pub enum Capability {
     CAP_PERFMON = nr::CAP_PERFMON,
     /// `CAP_BPF` (from Linux, >= 5.8).
     CAP_BPF = nr::CAP_BPF,
+    /// `CAP_CHECKPOINT_RESTORE` (from Linux, >= 5.9).
+    CAP_CHECKPOINT_RESTORE = nr::CAP_CHECKPOINT_RESTORE,
     #[doc(hidden)]
     __Nonexhaustive,
 }
@@ -183,6 +185,7 @@ impl std::fmt::Display for Capability {
             Capability::CAP_AUDIT_READ => "CAP_AUDIT_READ",
             Capability::CAP_PERFMON => "CAP_PERFMON",
             Capability::CAP_BPF => "CAP_BPF",
+            Capability::CAP_CHECKPOINT_RESTORE => "CAP_CHECKPOINT_RESTORE",
             Capability::__Nonexhaustive => unreachable!("invalid capability"),
         };
         write!(f, "{}", name)
@@ -234,6 +237,7 @@ impl std::str::FromStr for Capability {
             "CAP_AUDIT_READ" => Ok(Capability::CAP_AUDIT_READ),
             "CAP_PERFMON" => Ok(Capability::CAP_PERFMON),
             "CAP_BPF" => Ok(Capability::CAP_BPF),
+            "CAP_CHECKPOINT_RESTORE" => Ok(Capability::CAP_CHECKPOINT_RESTORE),
             _ => Err(format!("invalid capability: {}", s).into()),
         }
     }
@@ -389,6 +393,7 @@ pub fn all() -> CapsHashSet {
         Capability::CAP_AUDIT_READ,
         Capability::CAP_PERFMON,
         Capability::CAP_BPF,
+        Capability::CAP_CHECKPOINT_RESTORE,
     ];
     CapsHashSet::from_iter(slice)
 }

--- a/src/nr.rs
+++ b/src/nr.rs
@@ -40,6 +40,7 @@ pub const CAP_BLOCK_SUSPEND: u8 = 36;
 pub const CAP_AUDIT_READ: u8 = 37;
 pub const CAP_PERFMON: u8 = 38;
 pub const CAP_BPF: u8 = 39;
+pub const CAP_CHECKPOINT_RESTORE: u8 = 40;
 
 /* from <sys/prctl.h> */
 


### PR DESCRIPTION
This adds the new capability `CAP_CHECKPOINT_RESTORE` (number `40`) which has been
introduced in Linux 5.9.

Ref: https://github.com/torvalds/linux/commit/124ea650d3072b005457faed69909221c2905a1f
Closes: #61 