### PR TITLE
lib: fix bounding drop error message

### DIFF
--- a/src/bounding.rs
+++ b/src/bounding.rs
@@ -17,7 +17,7 @@ pub fn drop(cap: Capability) -> Result<(), CapsError> {
     match ret {
         0 => Ok(()),
         _ => Err(CapsError::from(format!(
-            "PR_CAPBSET_READ failure, errno {}",
+            "PR_CAPBSET_DROP failure, errno {}",
             errno::errno()
         ))),
     }


### PR DESCRIPTION
A trivial flaw that mssively confused me today:
 
The returned on a `PR_CAPBSET_DROP` error is fixed to the acutally used prctl value that failed.

