### PR TITLE
ci: bump linting toolchain to latest stable

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
   # Minimum supported Rust version (MSRV)
   ACTION_MSRV_TOOLCHAIN: 1.36.0
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.44.0
+  ACTION_LINTS_TOOLCHAIN: 1.53.0
 
 jobs:
   tests-stable:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,9 @@ pub enum CapSet {
 ///
 /// All capabilities supported by Linux, including standard
 /// POSIX and custom ones. See `capabilities(7)`.
-#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
+#[allow(clippy::manual_non_exhaustive)]
 #[allow(non_camel_case_types)]
+#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum Capability {
     /// `CAP_CHOWN` (from POSIX)


### PR DESCRIPTION
This bumps clippy to 1.53.0 and adapts the code for new warnings.