### PR TITLE
Remove dependency on `errno` crate in favor of std functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ exclude = [
 ]
 
 [dependencies]
-errno = "^0.2"
 libc = "^0.2"
 thiserror = "^1.0"
 serde = { version = "^1.0", features = ["derive"], optional = true}

--- a/src/ambient.rs
+++ b/src/ambient.rs
@@ -4,12 +4,17 @@ use crate::errors::CapsError;
 use crate::nr;
 use crate::runtime;
 use crate::{Capability, CapsHashSet};
+use std::io::Error;
 
 pub fn clear() -> Result<(), CapsError> {
     let ret = unsafe { libc::prctl(nr::PR_CAP_AMBIENT, nr::PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0) };
     match ret {
         0 => Ok(()),
-        _ => Err(format!("PR_CAP_AMBIENT_CLEAR_ALL failure, errno {}", errno::errno()).into()),
+        _ => Err(format!(
+            "PR_CAP_AMBIENT_CLEAR_ALL failure: {}",
+            Error::last_os_error()
+        )
+        .into()),
     }
 }
 
@@ -25,7 +30,7 @@ pub fn drop(cap: Capability) -> Result<(), CapsError> {
     };
     match ret {
         0 => Ok(()),
-        _ => Err(format!("PR_CAP_AMBIENT_LOWER failure, errno {}", errno::errno()).into()),
+        _ => Err(format!("PR_CAP_AMBIENT_LOWER failure: {}", Error::last_os_error()).into()),
     }
 }
 
@@ -42,7 +47,7 @@ pub fn has_cap(cap: Capability) -> Result<bool, CapsError> {
     match ret {
         0 => Ok(false),
         1 => Ok(true),
-        _ => Err(format!("PR_CAP_AMBIENT_IS_SET failure, errno {}", errno::errno()).into()),
+        _ => Err(format!("PR_CAP_AMBIENT_IS_SET failure: {}", Error::last_os_error()).into()),
     }
 }
 
@@ -58,7 +63,7 @@ pub fn raise(cap: Capability) -> Result<(), CapsError> {
     };
     match ret {
         0 => Ok(()),
-        _ => Err(format!("PR_CAP_AMBIENT_RAISE failure, errno {}", errno::errno()).into()),
+        _ => Err(format!("PR_CAP_AMBIENT_RAISE failure: {}", Error::last_os_error()).into()),
     }
 }
 

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,6 +1,7 @@
 use crate::errors::CapsError;
 use crate::nr;
 use crate::{CapSet, Capability, CapsHashSet};
+use std::io::Error;
 
 #[allow(clippy::unreadable_literal)]
 const CAPS_V3: u32 = 0x20080522;
@@ -9,7 +10,7 @@ fn capget(hdr: &mut CapUserHeader, data: &mut CapUserData) -> Result<(), CapsErr
     let r = unsafe { libc::syscall(nr::CAPGET, hdr, data) };
     match r {
         0 => Ok(()),
-        _ => Err(format!("capget failure, errno {}", errno::errno()).into()),
+        _ => Err(format!("capget failure: {}", Error::last_os_error()).into()),
     }
 }
 
@@ -17,7 +18,7 @@ fn capset(hdr: &mut CapUserHeader, data: &CapUserData) -> Result<(), CapsError> 
     let r = unsafe { libc::syscall(nr::CAPSET, hdr, data) };
     match r {
         0 => Ok(()),
-        _ => Err(format!("capset failure, errno {}", errno::errno()).into()),
+        _ => Err(format!("capset failure: {}", Error::last_os_error()).into()),
     }
 }
 

--- a/src/bounding.rs
+++ b/src/bounding.rs
@@ -2,6 +2,7 @@ use crate::errors::CapsError;
 use crate::nr;
 use crate::runtime;
 use crate::Capability;
+use std::io::Error;
 
 pub fn clear() -> Result<(), CapsError> {
     for c in super::all() {
@@ -17,8 +18,8 @@ pub fn drop(cap: Capability) -> Result<(), CapsError> {
     match ret {
         0 => Ok(()),
         _ => Err(CapsError::from(format!(
-            "PR_CAPBSET_DROP failure, errno {}",
-            errno::errno()
+            "PR_CAPBSET_DROP failure: {}",
+            Error::last_os_error()
         ))),
     }
 }
@@ -29,8 +30,8 @@ pub fn has_cap(cap: Capability) -> Result<bool, CapsError> {
         0 => Ok(false),
         1 => Ok(true),
         _ => Err(CapsError::from(format!(
-            "PR_CAPBSET_READ failure, errno {}",
-            errno::errno()
+            "PR_CAPBSET_READ failure: {}",
+            Error::last_os_error()
         ))),
     }
 }

--- a/src/securebits.rs
+++ b/src/securebits.rs
@@ -6,6 +6,7 @@
 
 use crate::errors::CapsError;
 use crate::nr;
+use std::io::Error;
 
 /// Return whether the current thread's "keep capabilities" flag is set.
 pub fn has_keepcaps() -> Result<bool, CapsError> {
@@ -14,8 +15,8 @@ pub fn has_keepcaps() -> Result<bool, CapsError> {
         0 => Ok(false),
         1 => Ok(true),
         _ => Err(CapsError::from(format!(
-            "PR_GET_KEEPCAPS failure, errno {}",
-            errno::errno()
+            "PR_GET_KEEPCAPS failure: {}",
+            Error::last_os_error()
         ))),
     }
 }
@@ -27,8 +28,8 @@ pub fn set_keepcaps(keep_caps: bool) -> Result<(), CapsError> {
     match ret {
         0 => Ok(()),
         _ => Err(CapsError::from(format!(
-            "PR_SET_KEEPCAPS failure, errno {}",
-            errno::errno()
+            "PR_SET_KEEPCAPS failure: {}",
+            Error::last_os_error()
         ))),
     }
 }


### PR DESCRIPTION
Unsure if there was a reason for the decision to use the errno crate, but if you just need error printing `std::io::Error::last_os_error()` will do basically the same thing afaik.