### PR TITLE
Bump the minimum supported Rust version to 1.48.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.36.0
+  ACTION_MSRV_TOOLCHAIN: 1.48.0
   # Pinned toolchain for linting
   ACTION_LINTS_TOOLCHAIN: 1.53.0
 


### PR DESCRIPTION
Would you be willing to bump caps' MSRV to 1.48, so that [rust-errno]
can migrate from winapi to windows-sys?

This isn't urgent, but if it works out, it would eliminate the last winapi
dependency for rustix and some of its users, so I figured it's worth
asking. windows-sys depends on at least Rust 1.48, so this will require
bumping rust-errno's MSRV. caps is [one of rust-errno's biggest users].

Last time cap's bumped its MSRV was #46 on 2020-01-09, bumping to Rust
1.36, which was released on 2019-07-04, so it was about 6 months old
at that point.  Rust 1.48 was released on 2020-11-19, which is about a
year and a half old now.

caps is depended on nix with an MSRV of 1.46, however it is only a
dev-dependency.

[rust-errno]: https://github.com/lambda-fairy/rust-errno
[one of rust-errno's biggest users]: https://github.com/lambda-fairy/rust-errno/pull/48