### PR TITLE
Add CAPGET and CAPSET for LoongArch64

### DIFF
--- a/src/nr.rs
+++ b/src/nr.rs
@@ -120,3 +120,8 @@ pub const CAPSET: i64 = 22;
 pub const CAPGET: i64 = 90;
 #[cfg(target_arch = "riscv64")]
 pub const CAPSET: i64 = 91;
+
+#[cfg(target_arch = "loongarch64")]
+pub const CAPGET: i64 = 90;
+#[cfg(target_arch = "loongarch64")]
+pub const CAPSET: i64 = 91;


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html