### PR TITLE
Use bitflags to store capabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [
 [dependencies]
 libc = "^0.2"
 thiserror = "^1.0"
+bitflags = "^2.8"
 serde = { version = "^1.0", features = ["derive"], optional = true}
 
 [features]

--- a/examples/all_caps.rs
+++ b/examples/all_caps.rs
@@ -10,27 +10,30 @@ The runtime set can be introspected in two different ways: via procfs
 mechanisms are available, they produce the exact same result.
 !*/
 
+use caps::CapsBitFlags;
+
 type ExResult<T> = Result<T, Box<dyn std::error::Error + 'static>>;
 
 fn main() -> ExResult<()> {
-    let library_set = caps::all();
-    let runtime_set = caps::runtime::procfs_all_supported(None).unwrap_or_else(|e| {
-        eprintln!("procfs introspection failed: {}", e);
-        caps::runtime::thread_all_supported()
-    });
+    let library_set: CapsBitFlags = caps::all_caps();
+    let runtime_set: CapsBitFlags =
+        caps::runtime::procfs_all_supported_caps(None).unwrap_or_else(|e| {
+            eprintln!("procfs introspection failed: {}", e);
+            caps::runtime::thread_all_supported_caps()
+        });
 
     println!("Capabilities tally:");
-    println!(" -> known by this library: {}.", library_set.len());
-    println!(" -> known by the current kernel: {}.\n", runtime_set.len());
+    println!(" -> known by this library: {}.", library_set.iter().count());
+    println!(" -> known by the current kernel: {}.\n", runtime_set.iter().count());
 
     println!("Library vs kernel differences:");
     println!(
         " -> newer caps only in the library set: {:?}.",
-        library_set.difference(&runtime_set)
+        library_set.difference(runtime_set)
     );
     println!(
         " -> newer caps only in the current kernel set: {:?}.",
-        runtime_set.difference(&library_set)
+        runtime_set.difference(library_set)
     );
 
     Ok(())

--- a/examples/clear_permitted.rs
+++ b/examples/clear_permitted.rs
@@ -9,12 +9,12 @@
 type ExResult<T> = Result<T, Box<dyn std::error::Error + 'static>>;
 
 fn main() -> ExResult<()> {
-    use caps::{CapSet, Capability};
+    use caps::{CapSet, Capability, CapsBitFlags};
 
     // Check if `CAP_CHOWN` was originally available.
-    let cur = caps::read(None, CapSet::Permitted)?;
+    let cur: CapsBitFlags = caps::read_caps(None, CapSet::Permitted)?;
     println!("-> Current permitted caps: {:?}.", cur);
-    let cur = caps::read(None, CapSet::Effective)?;
+    let cur: CapsBitFlags = caps::read_caps(None, CapSet::Effective)?;
     println!("-> Current effective caps: {:?}.", cur);
     let perm_chown = caps::has_cap(None, CapSet::Permitted, Capability::CAP_CHOWN);
     assert!(perm_chown.is_ok());
@@ -28,30 +28,30 @@ fn main() -> ExResult<()> {
     let r = caps::clear(None, CapSet::Effective);
     assert!(r.is_ok());
     println!("Cleared effective caps.");
-    let cur = caps::read(None, CapSet::Effective)?;
+    let cur: CapsBitFlags = caps::read_caps(None, CapSet::Effective)?;
     println!("-> Current effective caps: {:?}.", cur);
 
     // Since `CAP_CHOWN` is still in permitted, it can be raised again.
     let r = caps::raise(None, CapSet::Effective, Capability::CAP_CHOWN);
     assert!(r.is_ok());
     println!("Raised CAP_CHOWN in effective set.");
-    let cur = caps::read(None, CapSet::Effective)?;
+    let cur: CapsBitFlags = caps::read_caps(None, CapSet::Effective)?;
     println!("-> Current effective caps: {:?}.", cur);
 
     // Clearing Permitted also impacts effective.
     let r = caps::clear(None, CapSet::Permitted);
     assert!(r.is_ok());
     println!("Cleared permitted caps.");
-    let cur = caps::read(None, CapSet::Permitted)?;
+    let cur: CapsBitFlags = caps::read_caps(None, CapSet::Permitted)?;
     println!("-> Current permitted caps: {:?}.", cur);
-    let cur = caps::read(None, CapSet::Effective)?;
+    let cur: CapsBitFlags = caps::read_caps(None, CapSet::Effective)?;
     println!("-> Current effective caps: {:?}.", cur);
 
     // Trying to raise `CAP_CHOWN` now fails.
     let r = caps::raise(None, CapSet::Effective, Capability::CAP_CHOWN);
     assert!(r.is_err());
     println!("Tried to raise CAP_CHOWN but failed.");
-    let cur = caps::read(None, CapSet::Effective)?;
+    let cur: CapsBitFlags = caps::read_caps(None, CapSet::Effective)?;
     println!("-> Current effective caps: {:?}.", cur);
 
     Ok(())

--- a/examples/legacy.rs
+++ b/examples/legacy.rs
@@ -1,11 +1,11 @@
-use caps::runtime;
+use caps::{runtime, CapsBitFlags};
 
 fn main() {
     let amb_set = runtime::ambient_set_supported().is_ok();
     println!("Ambient set supported: {}", amb_set);
 
-    let all = caps::all();
-    let supported = runtime::thread_all_supported();
-    let missing = all.difference(&supported);
+    let all: CapsBitFlags = caps::all_caps();
+    let supported = runtime::thread_all_supported_caps();
+    let missing = all.difference(supported);
     println!("Unsupported new capabilities: {:?}", missing);
 }

--- a/src/caps.rs
+++ b/src/caps.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, convert::TryInto, iter::FromIterator, marker::PhantomData};
 
-/// An `HashSet` specialized on `Capability`.
+/// List of [`Capability`] stored as [`HashSet`].
 pub type CapsHashSet = std::collections::HashSet<Capability>;
 
 macro_rules! capability_list {
@@ -179,6 +179,8 @@ impl From<CapsHashSet> for CapsBitFlags {
 }
 
 /// A collection capable of storing a set of [`Capability`].
+///
+/// Both [`CapsBitFlags`] and [`CapsHashSet`] implements this trait, using different inner containers.
 pub trait CapsList: FromIterator<Capability> + Clone {
     type Iter<'a>: Iterator<Item = Capability>
     where

--- a/src/caps.rs
+++ b/src/caps.rs
@@ -1,0 +1,110 @@
+/// An `HashSet` specialized on `Capability`.
+pub type CapsHashSet = std::collections::HashSet<Capability>;
+
+macro_rules! capability_list {
+    ($($capability:ident $(: $doc:literal)? ),*) => {
+        /// Linux capabilities.
+        ///
+        /// All capabilities supported by Linux, including standard
+        /// POSIX and custom ones. See `capabilities(7)`.
+        #[allow(clippy::manual_non_exhaustive)]
+        #[allow(non_camel_case_types)]
+        #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
+        #[repr(u8)]
+        #[cfg_attr(
+            feature = "serde_support",
+            derive(serde::Serialize, serde::Deserialize)
+        )]
+        pub enum Capability {
+            $(
+                $(#[doc = $doc])?
+                $capability = crate::nr::$capability
+            ),*
+        }
+        impl ::std::fmt::Display for Capability {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                let name = match *self {
+                    $(
+                        Self::$capability => stringify!($capability)
+                    ),*
+                };
+                write!(f, "{}", name)
+            }
+        }
+        impl ::std::str::FromStr for Capability {
+            type Err = crate::CapsError;
+
+            fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
+                match s {
+                    $(
+                        stringify!($capability) => Ok(Self::$capability),
+                    )*
+                    _ => Err(format!("invalid capability: {}", s).into())
+                }
+            }
+        }
+
+        /// Return the set of all capabilities supported by this library.
+        pub fn all() -> CapsHashSet {
+            ::std::iter::FromIterator::from_iter([$(Capability::$capability),*])
+        }
+    };
+}
+
+capability_list!(
+    CAP_CHOWN: "`CAP_CHOWN` (from POSIX)",
+    CAP_DAC_OVERRIDE: "`CAP_DAC_OVERRIDE` (from POSIX)",
+    CAP_DAC_READ_SEARCH: "`CAP_DAC_READ_SEARCH` (from POSIX)",
+    CAP_FOWNER: "`CAP_FOWNER` (from POSIX)",
+    CAP_FSETID: "`CAP_FSETID` (from POSIX)",
+    CAP_KILL: "`CAP_KILL` (from POSIX)",
+    CAP_SETGID: "`CAP_SETGID` (from POSIX)",
+    CAP_SETUID: "`CAP_SETUID` (from POSIX)",
+    CAP_SETPCAP: "`CAP_SETPCAP` (from Linux)",
+    CAP_LINUX_IMMUTABLE,
+    CAP_NET_BIND_SERVICE,
+    CAP_NET_BROADCAST,
+    CAP_NET_ADMIN,
+    CAP_NET_RAW,
+    CAP_IPC_LOCK,
+    CAP_IPC_OWNER,
+    CAP_SYS_MODULE: "`CAP_SYS_MODULE` (from Linux)",
+    CAP_SYS_RAWIO: "`CAP_SYS_RAWIO` (from Linux)",
+    CAP_SYS_CHROOT: "`CAP_SYS_CHROOT` (from Linux)",
+    CAP_SYS_PTRACE: "`CAP_SYS_PTRACE` (from Linux)",
+    CAP_SYS_PACCT: "`CAP_SYS_PACCT` (from Linux)",
+    CAP_SYS_ADMIN: "`CAP_SYS_ADMIN` (from Linux)",
+    CAP_SYS_BOOT: "`CAP_SYS_BOOT` (from Linux)",
+    CAP_SYS_NICE: "`CAP_SYS_NICE` (from Linux)",
+    CAP_SYS_RESOURCE: "`CAP_SYS_RESOURCE` (from Linux)",
+    CAP_SYS_TIME: "`CAP_SYS_TIME` (from Linux)",
+    CAP_SYS_TTY_CONFIG: "`CAP_SYS_TTY_CONFIG` (from Linux)",
+    CAP_MKNOD: "`CAP_SYS_MKNOD` (from Linux, >= 2.4)",
+    CAP_LEASE: "`CAP_LEASE` (from Linux, >= 2.4)",
+    CAP_AUDIT_WRITE,
+    CAP_AUDIT_CONTROL: "`CAP_AUDIT_CONTROL` (from Linux, >= 2.6.11)",
+    CAP_SETFCAP,
+    CAP_MAC_OVERRIDE,
+    CAP_MAC_ADMIN,
+    CAP_SYSLOG: "`CAP_SYSLOG` (from Linux, >= 2.6.37)",
+    CAP_WAKE_ALARM: "`CAP_WAKE_ALARM` (from Linux, >= 3.0)",
+    CAP_BLOCK_SUSPEND,
+    CAP_AUDIT_READ: "`CAP_AUDIT_READ` (from Linux, >= 3.16).",
+    CAP_PERFMON: "`CAP_PERFMON` (from Linux, >= 5.8).",
+    CAP_BPF: "`CAP_BPF` (from Linux, >= 5.8).",
+    CAP_CHECKPOINT_RESTORE: "`CAP_CHECKPOINT_RESTORE` (from Linux, >= 5.9)."
+);
+
+impl Capability {
+    /// Returns the bitmask corresponding to this capability value.
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub fn bitmask(&self) -> u64 {
+        1u64 << (*self as u8)
+    }
+
+    /// Returns the index of this capability, i.e. its kernel-defined value.
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub fn index(&self) -> u8 {
+        *self as u8
+    }
+}

--- a/src/caps.rs
+++ b/src/caps.rs
@@ -18,15 +18,18 @@ macro_rules! capability_list {
         pub enum Capability {
             $(
                 $(#[doc = $doc])?
-                $capability = crate::nr::$capability
-            ),*
+                $capability = crate::nr::$capability,
+            )*
+            #[doc(hidden)]
+            __Nonexhaustive,
         }
         impl ::std::fmt::Display for Capability {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 let name = match *self {
                     $(
-                        Self::$capability => stringify!($capability)
-                    ),*
+                        Self::$capability => stringify!($capability),
+                    )*
+                    Self::__Nonexhaustive => unreachable!("invalid capability")
                 };
                 write!(f, "{}", name)
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -56,10 +56,10 @@ pub fn procfs_all_supported_caps<T: CapsList>(
             .map_err(|e| format!("failed to parse '{}': {}", last_cap_path.display(), e))?
     };
 
-    let mut supported: T = super::all_caps();
-    for c in supported.clone().iter_caps() {
-        if c.index() > max_cap {
-            supported.remove_cap(&c);
+    let mut supported = T::empty();
+    for c in crate::caps::all_iter() {
+        if c.index() <= max_cap {
+            supported.insert_cap(c);
         }
     }
     Ok(supported)
@@ -81,10 +81,10 @@ pub fn procfs_all_supported(proc_mountpoint: Option<PathBuf>) -> Result<CapsHash
 /// It internally uses `prctl(2)` and `PR_CAPBSET_READ`; if those are
 /// unavailable, this will result in an empty set.
 pub fn thread_all_supported_caps<T: CapsList>() -> T {
-    let mut supported: T = super::all_caps();
-    for c in supported.clone().iter_caps() {
-        if super::has_cap(None, CapSet::Bounding, c).is_err() {
-            supported.remove_cap(&c);
+    let mut supported = T::empty();
+    for c in crate::caps::all_iter() {
+        if super::has_cap(None, CapSet::Bounding, c).is_ok() {
+            supported.insert_cap(c);
         }
     }
     supported

--- a/tests/ambient.rs
+++ b/tests/ambient.rs
@@ -5,13 +5,13 @@ fn test_ambient_has_cap() {
 
 #[test]
 fn test_ambient_read() {
-    caps::read(None, caps::CapSet::Ambient).unwrap();
+    caps::read_caps::<caps::CapsBitFlags>(None, caps::CapSet::Ambient).unwrap();
 }
 
 #[test]
 fn test_ambient_clear() {
     caps::clear(None, caps::CapSet::Ambient).unwrap();
-    let empty = caps::read(None, caps::CapSet::Ambient).unwrap();
+    let empty = caps::read_caps::<caps::CapsHashSet>(None, caps::CapSet::Ambient).unwrap();
     assert_eq!(empty.len(), 0);
 }
 
@@ -45,10 +45,10 @@ fn test_ambient_raise() {
 #[test]
 fn test_ambient_set() {
     let mut v = caps::CapsHashSet::new();
-    caps::set(None, caps::CapSet::Ambient, &v).unwrap();
-    let empty = caps::read(None, caps::CapSet::Ambient).unwrap();
+    caps::set_caps(None, caps::CapSet::Ambient, &v).unwrap();
+    let empty = caps::read_caps::<caps::CapsHashSet>(None, caps::CapSet::Ambient).unwrap();
     assert_eq!(empty.len(), 0);
     v.insert(caps::Capability::CAP_CHOWN);
     caps::drop(None, caps::CapSet::Ambient, caps::Capability::CAP_CHOWN).unwrap();
-    assert!(caps::set(None, caps::CapSet::Ambient, &v).is_err());
+    assert!(caps::set_caps(None, caps::CapSet::Ambient, &v).is_err());
 }

--- a/tests/bounding.rs
+++ b/tests/bounding.rs
@@ -10,7 +10,7 @@ fn test_bounding_has_cap() {
 
 #[test]
 fn test_bounding_read() {
-    caps::read(None, caps::CapSet::Bounding).unwrap();
+    caps::read_caps::<caps::CapsBitFlags>(None, caps::CapSet::Bounding).unwrap();
 }
 
 #[test]
@@ -18,7 +18,7 @@ fn test_bounding_clear() {
     let ret = caps::clear(None, caps::CapSet::Bounding);
     if caps::has_cap(None, caps::CapSet::Effective, caps::Capability::CAP_SETPCAP).unwrap() {
         ret.unwrap();
-        let empty = caps::read(None, caps::CapSet::Bounding).unwrap();
+        let empty = caps::read_caps::<caps::CapsHashSet>(None, caps::CapSet::Bounding).unwrap();
         assert_eq!(empty.len(), 0);
     } else {
         assert!(ret.is_err());
@@ -34,7 +34,7 @@ fn test_bounding_drop() {
     );
     if caps::has_cap(None, caps::CapSet::Effective, caps::Capability::CAP_SETPCAP).unwrap() {
         ret.unwrap();
-        let set = caps::read(None, caps::CapSet::Bounding).unwrap();
+        let set = caps::read_caps::<caps::CapsHashSet>(None, caps::CapSet::Bounding).unwrap();
         assert!(!set.contains(&caps::Capability::CAP_SYS_CHROOT));
     } else {
         assert!(ret.is_err());
@@ -54,5 +54,5 @@ fn test_bounding_raise() {
 #[test]
 fn test_bounding_set() {
     let v = caps::CapsHashSet::new();
-    assert!(caps::set(None, caps::CapSet::Bounding, &v).is_err());
+    assert!(caps::set_caps(None, caps::CapSet::Bounding, &v).is_err());
 }

--- a/tests/effective.rs
+++ b/tests/effective.rs
@@ -5,13 +5,13 @@ fn test_effective_has_cap() {
 
 #[test]
 fn test_effective_read() {
-    caps::read(None, caps::CapSet::Effective).unwrap();
+    caps::read_caps::<caps::CapsBitFlags>(None, caps::CapSet::Effective).unwrap();
 }
 
 #[test]
 fn test_effective_clear() {
     caps::clear(None, caps::CapSet::Effective).unwrap();
-    let empty = caps::read(None, caps::CapSet::Effective).unwrap();
+    let empty = caps::read_caps::<caps::CapsHashSet>(None, caps::CapSet::Effective).unwrap();
     assert_eq!(empty.len(), 0);
 }
 
@@ -37,10 +37,10 @@ fn test_effective_raise() {
 #[test]
 fn test_effective_set() {
     let mut v = caps::CapsHashSet::new();
-    caps::set(None, caps::CapSet::Effective, &v).unwrap();
-    let empty = caps::read(None, caps::CapSet::Effective).unwrap();
+    caps::set_caps(None, caps::CapSet::Effective, &v).unwrap();
+    let empty = caps::read_caps::<caps::CapsHashSet>(None, caps::CapSet::Effective).unwrap();
     assert_eq!(empty.len(), 0);
     v.insert(caps::Capability::CAP_CHOWN);
     caps::drop(None, caps::CapSet::Ambient, caps::Capability::CAP_CHOWN).unwrap();
-    assert!(caps::set(None, caps::CapSet::Ambient, &v).is_err());
+    assert!(caps::set_caps(None, caps::CapSet::Ambient, &v).is_err());
 }

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -7,18 +7,18 @@ fn test_ambient_supported() {
 
 #[test]
 fn test_thread_all_supported() {
-    assert!(runtime::thread_all_supported().len() > 0);
-    assert!(runtime::thread_all_supported().len() <= caps::all().len());
+    assert!(runtime::thread_all_supported_caps::<caps::CapsHashSet>().len() > 0);
+    assert!(runtime::thread_all_supported_caps::<caps::CapsHashSet>().len() <= caps::all_caps::<caps::CapsHashSet>().len());
 }
 
 #[test]
 fn test_procfs_all_supported() {
     use std::path::PathBuf;
 
-    let p1 = runtime::procfs_all_supported(None).unwrap();
-    let p2 = runtime::procfs_all_supported(Some(PathBuf::from("/proc"))).unwrap();
-    let thread = runtime::thread_all_supported();
-    let all = caps::all();
+    let p1 = runtime::procfs_all_supported_caps::<caps::CapsHashSet>(None).unwrap();
+    let p2 = runtime::procfs_all_supported_caps::<caps::CapsHashSet>(Some(PathBuf::from("/proc"))).unwrap();
+    let thread: caps::CapsHashSet = runtime::thread_all_supported_caps();
+    let all = caps::all_caps::<caps::CapsHashSet>();
 
     assert!(thread.len() > 0);
     assert!(thread.len() <= all.len());


### PR DESCRIPTION
Implement a new type called `CapsBitFlags`, which uses [`BitFlags`](https://docs.rs/bitflags/latest/bitflags/index.html) to store capabilities.

All public interfaces now take `<T: CapsList>` (which can be either `CapsHashSet` or `CapsBitFlags`) as capabilities. These new interfaces are named `*_caps`, and old ones are marked as deprecate. This is because some consumers may need interfaces to return or accept concrete types, so removing old interfaces will make the compiler very confused.

Performance wise, consumers using old `CapsHashSet` should be fine since it should at most [`add a memcpy()`](https://github.com/hafeoz/caps-rs/blob/7a26d6357ab223f8595c10fb5f48f7cde402de01/src/caps.rs#L204), and new consumers with `CapsBitFlags` will be able to handle all flags without hashing.

Closes #86