### PR TITLE
ci: update minimum and linting toolchain to 1.61

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,9 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.36.0
+  ACTION_MSRV_TOOLCHAIN: 1.63.0
   # Pinned toolchain for linting
-  ACTION_LINTS_TOOLCHAIN: 1.53.0
+  ACTION_LINTS_TOOLCHAIN: 1.63.0
 
 jobs:
   tests-stable:


### PR DESCRIPTION
This updates the minimum Rust toolchain used in CI, in order to match requirements from all dependencies.