### PR TITLE
Release 0.5.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caps"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2018"
 rust-version = "1.63"
 authors = ["Luca Bruno <lucab@lucabruno.net>"]


### PR DESCRIPTION
Changes:
 * Update minimum toolchain to 1.63
 * Remove `thiserror` dependency
 * Gracefully handle unsupported capabilities in clear and read operations